### PR TITLE
if filename is a file object, fitslib.extract_filename gets the file nam...

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -2721,6 +2721,8 @@ def check_extver(extver):
     return extver
 
 def extract_filename(filename):
+    if( type(filename) == file ):
+        filename = filename.name
     if filename[0] == "!":
         filename=filename[1:]
     filename = os.path.expandvars(filename)


### PR DESCRIPTION
...e string.

can be useful when, e.g., input and/or output file names are opened for checks (e.g. argparse.FileType)  
