### PR TITLE
Some improvements

### DIFF
--- a/fitsio/__init__.py
+++ b/fitsio/__init__.py
@@ -20,7 +20,7 @@ from .fitslib import READONLY
 from .fitslib import READWRITE
 from .fitslib import cfitsio_version
 
-from .fitslib import BINARY_TBL, ASCII_TBL, IMAGE_HDU
+from fitslib import BINARY_TBL, ASCII_TBL, IMAGE_HDU
 
 
-from . import test
+import test

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -35,6 +35,9 @@
 // not sure where this is defined in numpy...
 #define NUMPY_MAX_DIMS 32
 
+#define ALLOW_NOGIL //PyThreadState *_save; int _evaltmp123_;
+#define NOGIL(x) ({PyThreadState * _save1=PyEval_SaveThread(); int _evaltmp123_ = (x); PyEval_RestoreThread(_save1); _evaltmp123_;})
+
 struct PyFITSObject {
     PyObject_HEAD
     fitsfile* fits;
@@ -323,6 +326,8 @@ void append_string_to_list(PyObject* list, const char* str) {
 static int
 PyFITSObject_init(struct PyFITSObject* self, PyObject *args, PyObject *kwds)
 {
+    ALLOW_NOGIL
+
     char* filename;
     int mode;
     int status=0;
@@ -334,12 +339,12 @@ PyFITSObject_init(struct PyFITSObject* self, PyObject *args, PyObject *kwds)
 
     if (create) {
         // create and open
-        if (fits_create_file(&self->fits, filename, &status)) {
+        if (NOGIL(fits_create_file(&self->fits, filename, &status))) {
             set_ioerr_string_from_status(status);
             return -1;
         }
     } else {
-        if (fits_open_file(&self->fits, filename, mode, &status)) {
+        if (NOGIL(fits_open_file(&self->fits, filename, mode, &status))) {
             set_ioerr_string_from_status(status);
             return -1;
         }
@@ -351,13 +356,14 @@ PyFITSObject_init(struct PyFITSObject* self, PyObject *args, PyObject *kwds)
 
 static PyObject *
 PyFITSObject_repr(struct PyFITSObject* self) {
+    ALLOW_NOGIL
 
     if (self->fits != NULL) {
         int status=0;
         char filename[FLEN_FILENAME];
         char repr[2056];
 
-        if (fits_file_name(self->fits, filename, &status)) {
+        if (NOGIL(fits_file_name(self->fits, filename, &status))) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
@@ -371,12 +377,13 @@ PyFITSObject_repr(struct PyFITSObject* self) {
 
 static PyObject *
 PyFITSObject_filename(struct PyFITSObject* self) {
+    ALLOW_NOGIL
 
     if (self->fits != NULL) {
         int status=0;
         char filename[FLEN_FILENAME];
         PyObject* fnameObj=NULL;
-        if (fits_file_name(self->fits, filename, &status)) {
+        if (NOGIL(fits_file_name(self->fits, filename, &status))) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
@@ -394,8 +401,10 @@ PyFITSObject_filename(struct PyFITSObject* self) {
 static PyObject *
 PyFITSObject_close(struct PyFITSObject* self)
 {
+    ALLOW_NOGIL
+
     int status=0;
-    if (fits_close_file(self->fits, &status)) {
+    if (NOGIL(fits_close_file(self->fits, &status))) {
         self->fits=NULL;
         /*
         set_ioerr_string_from_status(status);
@@ -411,8 +420,10 @@ PyFITSObject_close(struct PyFITSObject* self)
 static void
 PyFITSObject_dealloc(struct PyFITSObject* self)
 {
+    ALLOW_NOGIL
+
     int status=0;
-    fits_close_file(self->fits, &status);
+    NOGIL(fits_close_file(self->fits, &status));
 #if PY_MAJOR_VERSION >= 3
     // introduced in python 2.6
     Py_TYPE(self)->tp_free((PyObject*)self);
@@ -473,6 +484,8 @@ static npy_int64* get_int64_from_array(PyObject* arr, npy_intp* ncols) {
 // move hdu by name and possibly version, return the hdu number
 static PyObject *
 PyFITSObject_movnam_hdu(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int   status=0;
     int   hdutype=ANY_HDU; // means we don't care if its image or table
     char* extname=NULL;
@@ -488,12 +501,12 @@ PyFITSObject_movnam_hdu(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movnam_hdu(self->fits, hdutype, extname,  extver, &status)) {
+    if (NOGIL(fits_movnam_hdu(self->fits, hdutype, extname,  extver, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
     
-    fits_get_hdu_num(self->fits, &hdunum);
+    NOGIL(fits_get_hdu_num(self->fits, &hdunum));
     return PyLong_FromLong((long)hdunum);
 }
 
@@ -501,6 +514,8 @@ PyFITSObject_movnam_hdu(struct PyFITSObject* self, PyObject* args) {
 
 static PyObject *
 PyFITSObject_movabs_hdu(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL;
+
     int hdunum=0, hdutype=0;
     int status=0;
     PyObject* hdutypeObj=NULL;
@@ -514,7 +529,7 @@ PyFITSObject_movabs_hdu(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -525,6 +540,8 @@ PyFITSObject_movabs_hdu(struct PyFITSObject* self, PyObject* args) {
 // get info for the specified HDU
 static PyObject *
 PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0, hdutype=0, ext=0;
     int status=0, tstatus=0, is_compressed=0;
     PyObject* dict=NULL;
@@ -542,7 +559,7 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -560,28 +577,28 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
 
 
     tstatus=0;
-    if (fits_read_key(self->fits, TSTRING, "EXTNAME", extname, NULL, &tstatus)==0) {
+    if (NOGIL(fits_read_key(self->fits, TSTRING, "EXTNAME", extname, NULL, &tstatus))==0) {
         add_string_to_dict(dict, "extname", extname);
     } else {
         add_string_to_dict(dict, "extname", "");
     }
 
     tstatus=0;
-    if (fits_read_key(self->fits, TSTRING, "HDUNAME", hduname, NULL, &tstatus)==0) {
+    if (NOGIL(fits_read_key(self->fits, TSTRING, "HDUNAME", hduname, NULL, &tstatus))==0) {
         add_string_to_dict(dict, "hduname", hduname);
     } else {
         add_string_to_dict(dict, "hduname", "");
     }
 
     tstatus=0;
-    if (fits_read_key(self->fits, TINT, "EXTVER", &extver, NULL, &tstatus)==0) {
+    if (NOGIL(fits_read_key(self->fits, TINT, "EXTVER", &extver, NULL, &tstatus))==0) {
         add_long_to_dict(dict, "extver", (long)extver);
     } else {
         add_long_to_dict(dict, "extver", (long)0);
     }
 
     tstatus=0;
-    if (fits_read_key(self->fits, TINT, "HDUVER", &hduver, NULL, &tstatus)==0) {
+    if (NOGIL(fits_read_key(self->fits, TINT, "HDUVER", &hduver, NULL, &tstatus))==0) {
         add_long_to_dict(dict, "hduver", (long)hduver);
     } else {
         add_long_to_dict(dict, "hduver", (long)0);
@@ -605,18 +622,18 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
 
         //if (fits_read_imghdrll(self->fits, maxdim, simple_p, &bitpix, &ndims,
         //                       dims, pcount_p, gcount_p, extend_p, &status)) {
-        if (fits_get_img_paramll(self->fits, maxdim, &bitpix, &ndims, dims, &tstatus)) {
+        if (NOGIL(fits_get_img_paramll(self->fits, maxdim, &bitpix, &ndims, dims, &tstatus))) {
             add_string_to_dict(dict,"error","could not determine image parameters");
         } else {
             add_long_to_dict(dict,"ndims",(long)ndims);
             add_long_to_dict(dict,"img_type",(long)bitpix);
 
-            fits_get_img_equivtype(self->fits, &bitpix_equiv, &status);
+            NOGIL(fits_get_img_equivtype(self->fits, &bitpix_equiv, &status));
             add_long_to_dict(dict,"img_equiv_type",(long)bitpix_equiv);
 
             tstatus=0;
-            if (fits_read_key(self->fits, TSTRING, "ZCMPTYPE", 
-                              comptype, NULL, &tstatus)==0) {
+            if (NOGIL(fits_read_key(self->fits, TSTRING, "ZCMPTYPE", 
+                              comptype, NULL, &tstatus))==0) {
                 add_string_to_dict(dict,"comptype",comptype);
             } else {
                 add_none_to_dict(dict,"comptype");
@@ -637,8 +654,8 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
         PyObject* colinfo = PyList_New(0);
         int i=0,j=0;
 
-        fits_get_num_rowsll(self->fits, &nrows, &tstatus);
-        fits_get_num_cols(self->fits, &ncols, &tstatus);
+        NOGIL(fits_get_num_rowsll(self->fits, &nrows, &tstatus));
+        NOGIL(fits_get_num_cols(self->fits, &ncols, &tstatus));
         add_long_long_to_dict(dict,"nrows",(long long)nrows);
         add_long_to_dict(dict,"ncols",(long)ncols);
 
@@ -655,9 +672,9 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
                 stringlist_push_size(tforms, 70);
             }
             // just get the names: no other way to do it!
-            fits_read_btblhdrll(self->fits, ncols, NULL, NULL, 
+            NOGIL(fits_read_btblhdrll(self->fits, ncols, NULL, NULL, 
                                 names->data, tforms->data, 
-                                NULL, NULL, NULL, &tstatus);
+                                NULL, NULL, NULL, &tstatus));
 
             for (i=0; i<ncols; i++) {
                 d = PyDict_New();
@@ -668,17 +685,17 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
                 add_string_to_dict(d,"name",names->data[i]);
                 add_string_to_dict(d,"tform",tforms->data[i]);
 
-                fits_get_coltypell(self->fits, i+1, &type, &repeat, &width, &tstatus);
+                NOGIL(fits_get_coltypell(self->fits, i+1, &type, &repeat, &width, &tstatus));
                 add_long_to_dict(d,"type",(long)type);
                 add_long_long_to_dict(d,"repeat",(long long)repeat);
                 add_long_long_to_dict(d,"width",(long long)width);
 
-                fits_get_eqcoltypell(self->fits,i+1,&type,&repeat,&width, &tstatus);
+                NOGIL(fits_get_eqcoltypell(self->fits,i+1,&type,&repeat,&width, &tstatus));
                 add_long_to_dict(d,"eqtype",(long)type);
 
                 tstatus=0;
-                if (fits_read_tdimll(self->fits, i+1, maxdim, &ndims, dims, 
-                                     &tstatus)) {
+                if (NOGIL(fits_read_tdimll(self->fits, i+1, maxdim, &ndims, dims, 
+                                     &tstatus))) {
                     add_none_to_dict(d,"tdim");
                 } else {
                     PyObject* dimsObj=PyList_New(0);
@@ -713,8 +730,8 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
         PyObject* colinfo = PyList_New(0);
         int i=0,j=0;
 
-        fits_get_num_rowsll(self->fits, &nrows, &tstatus);
-        fits_get_num_cols(self->fits, &ncols, &tstatus);
+        NOGIL(fits_get_num_rowsll(self->fits, &nrows, &tstatus));
+        NOGIL(fits_get_num_cols(self->fits, &ncols, &tstatus));
         add_long_long_to_dict(dict,"nrows",(long long)nrows);
         add_long_to_dict(dict,"ncols",(long)ncols);
 
@@ -732,11 +749,11 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
             // just get the names: no other way to do it!
 
             //                                        rowlen nrows
-            fits_read_atblhdrll(self->fits, ncols, NULL, NULL,
+            NOGIL(fits_read_atblhdrll(self->fits, ncols, NULL, NULL,
             //          tfields             tbcol                units
                         NULL,   names->data, NULL, tforms->data, NULL,
             //          extname
-                        NULL, &tstatus);
+                        NULL, &tstatus));
 
 
 
@@ -749,17 +766,17 @@ PyFITSObject_get_hdu_info(struct PyFITSObject* self, PyObject* args) {
                 add_string_to_dict(d,"name",names->data[i]);
                 add_string_to_dict(d,"tform",tforms->data[i]);
 
-                fits_get_coltypell(self->fits, i+1, &type, &repeat, &width, &tstatus);
+                NOGIL(fits_get_coltypell(self->fits, i+1, &type, &repeat, &width, &tstatus));
                 add_long_to_dict(d,"type",(long)type);
                 add_long_long_to_dict(d,"repeat",(long long)repeat);
                 add_long_long_to_dict(d,"width",(long long)width);
 
-                fits_get_eqcoltypell(self->fits, i+1, &type, &repeat, &width, &tstatus);
+                NOGIL(fits_get_eqcoltypell(self->fits, i+1, &type, &repeat, &width, &tstatus));
                 add_long_to_dict(d,"eqtype",(long)type);
 
                 tstatus=0;
-                if (fits_read_tdimll(self->fits, i+1, maxdim, &ndims, dims, 
-                                                      &tstatus)) {
+                if (NOGIL(fits_read_tdimll(self->fits, i+1, maxdim, &ndims, dims, 
+                                                      &tstatus))) {
                     add_none_to_dict(dict,"tdim");
                 } else {
                     PyObject* dimsObj=PyList_New(0);
@@ -1104,11 +1121,13 @@ static int fits_to_npy_table_type(int fits_dtype, int* isvariable) {
 
 static int create_empty_hdu(struct PyFITSObject* self)
 {
+    ALLOW_NOGIL
+
     int status=0;
     int bitpix=SHORT_IMG;
     int naxis=0;
     long* naxes=NULL;
-    if (fits_create_img(self->fits, bitpix, naxis, naxes, &status)) {
+    if (NOGIL(fits_create_img(self->fits, bitpix, naxis, naxes, &status))) {
         set_ioerr_string_from_status(status);
         return 1;
     }
@@ -1184,6 +1203,8 @@ static int pyarray_get_ndim(PyObject* obj) {
 
 static PyObject *
 PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    ALLOW_NOGIL
+
     int ndims=0;
     long *dims=NULL;
     int image_datatype=0; // fits type for image, AKA bitpix
@@ -1256,7 +1277,7 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
             }
         }
 
-        if (fits_create_img(self->fits, image_datatype, ndims, dims, &status)) {
+        if (NOGIL(fits_create_img(self->fits, image_datatype, ndims, dims, &status))) {
             set_ioerr_string_from_status(status);
             goto create_image_hdu_cleanup;
         }
@@ -1265,12 +1286,12 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
         if (strlen(extname) > 0) {
 
             // comments are NULL
-            if (fits_update_key_str(self->fits, "EXTNAME", extname, NULL, &status)) {
+            if (NOGIL(fits_update_key_str(self->fits, "EXTNAME", extname, NULL, &status))) {
                 set_ioerr_string_from_status(status);
                 goto create_image_hdu_cleanup;
             }
             if (extver > 0) {
-                if (fits_update_key_lng(self->fits, "EXTVER", (LONGLONG) extver, NULL, &status)) {
+                if (NOGIL(fits_update_key_lng(self->fits, "EXTVER", (LONGLONG) extver, NULL, &status))) {
                     set_ioerr_string_from_status(status);
                     goto create_image_hdu_cleanup;
                 }
@@ -1278,7 +1299,7 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
         }
     }
     // this does a full close and reopen
-    if (fits_flush_file(self->fits, &status)) {
+    if (NOGIL(fits_flush_file(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         goto create_image_hdu_cleanup;
     }
@@ -1295,11 +1316,12 @@ create_image_hdu_cleanup:
 }
 
 
-
 // write the image to an existing HDU created using create_image_hdu
 // dims are not checked
 static PyObject *
 PyFITSObject_write_image(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
     LONGLONG nelements=1;
@@ -1322,7 +1344,7 @@ PyFITSObject_write_image(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1341,13 +1363,13 @@ PyFITSObject_write_image(struct PyFITSObject* self, PyObject* args) {
     data = PyArray_DATA(array);
     nelements = PyArray_SIZE(array);
     firstpixel = (LONGLONG) firstpixel_py;
-    if (fits_write_img(self->fits, datatype, firstpixel, nelements, data, &status)) {
+    if (NOGIL(fits_write_img(self->fits, datatype, firstpixel, nelements, data, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
     // this is a full file close and reopen
-    if (fits_flush_file(self->fits, &status)) {
+    if (NOGIL(fits_flush_file(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1364,6 +1386,8 @@ PyFITSObject_write_image(struct PyFITSObject* self, PyObject* args) {
  */
 static int 
 add_tdims_from_listobj(fitsfile* fits, PyObject* tdimObj, int ncols) {
+    ALLOW_NOGIL
+
     int status=0;
     size_t size=0, i=0;
     char keyname[20];
@@ -1399,7 +1423,7 @@ add_tdims_from_listobj(fitsfile* fits, PyObject* tdimObj, int ncols) {
             sprintf(keyname, "TDIM%d", colnum);
 
             tdim = get_object_as_string(tmp);
-            fits_write_key(fits, TSTRING, keyname, tdim, NULL, &status);
+            NOGIL(fits_write_key(fits, TSTRING, keyname, tdim, NULL, &status));
             free(tdim);
 
             if (status) {
@@ -1417,6 +1441,8 @@ add_tdims_from_listobj(fitsfile* fits, PyObject* tdimObj, int ncols) {
 // create a new table structure.  No physical rows are added yet.
 static PyObject *
 PyFITSObject_create_table_hdu(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    ALLOW_NOGIL
+
     int status=0;
     int table_type=0;
     int nfields=0;
@@ -1469,12 +1495,13 @@ PyFITSObject_create_table_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
         }
     }
     nfields = ttyp->size;
-    if ( fits_create_tbl(self->fits, table_type, nrows, nfields, 
-                         ttyp->data, tform->data, tunit->data, extname_use, &status) ) {
+    if (NOGIL(fits_create_tbl(self->fits, table_type, nrows, nfields, 
+                         ttyp->data, tform->data, tunit->data, extname_use, &status)) ) {
         set_ioerr_string_from_status(status);
         goto create_table_cleanup;
     }
 
+    /* add_tdims_from_listobj needs GIL */
     if (add_tdims_from_listobj(self->fits, tdimObj, nfields)) {
         status=99;
         goto create_table_cleanup;
@@ -1483,7 +1510,7 @@ PyFITSObject_create_table_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
     if (extname_use != NULL) {
         if (extver > 0) {
 
-            if (fits_update_key_lng(self->fits, "EXTVER", (LONGLONG) extver, NULL, &status)) {
+            if (NOGIL(fits_update_key_lng(self->fits, "EXTVER", (LONGLONG) extver, NULL, &status))) {
                 set_ioerr_string_from_status(status);
                 goto create_table_cleanup;
             }
@@ -1491,7 +1518,7 @@ PyFITSObject_create_table_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
     }
 
     // this does a full close and reopen
-    if (fits_flush_file(self->fits, &status)) {
+    if (NOGIL(fits_flush_file(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         goto create_table_cleanup;
     }
@@ -1515,6 +1542,8 @@ create_table_cleanup:
 // create a new table structure.  No physical rows are added yet.
 static PyObject *
 PyFITSObject_insert_col(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int colnum=0;
@@ -1532,12 +1561,12 @@ PyFITSObject_insert_col(struct PyFITSObject* self, PyObject* args, PyObject* kwd
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
-    if (fits_insert_col(self->fits, colnum, ttype, tform, &status)) {
+    if (NOGIL(fits_insert_col(self->fits, colnum, ttype, tform, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1552,7 +1581,7 @@ PyFITSObject_insert_col(struct PyFITSObject* self, PyObject* args, PyObject* kwd
         tmp = PyList_GetItem(tdimObj, 0);
 
         tdim = get_object_as_string(tmp);
-        fits_write_key(self->fits, TSTRING, keyname, tdim, NULL, &status);
+        NOGIL(fits_write_key(self->fits, TSTRING, keyname, tdim, NULL, &status));
         free(tdim);
 
         if (status) {
@@ -1562,7 +1591,7 @@ PyFITSObject_insert_col(struct PyFITSObject* self, PyObject* args, PyObject* kwd
     }
 
     // this does a full close and reopen
-    if (fits_flush_file(self->fits, &status)) {
+    if (NOGIL(fits_flush_file(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1583,6 +1612,7 @@ int write_string_column(
         LONGLONG  nelem,     /* I - number of strings to write              */
         char  *data,
         int  *status) {   /* IO - error status                           */
+    ALLOW_NOGIL
 
     LONGLONG i=0;
     LONGLONG twidth=0;
@@ -1597,8 +1627,7 @@ int write_string_column(
 
     strdata = malloc(nelem*sizeof(char*));
     if (strdata == NULL) {
-        PyErr_SetString(PyExc_MemoryError, "could not allocate temporary string pointers");
-        *status = 99;
+        *status = 113;
         return 1;
     }
     cdata = (char* ) data;
@@ -1606,8 +1635,7 @@ int write_string_column(
         strdata[i] = &cdata[twidth*i];
     }
 
-    if( fits_write_col_str(fits, colnum, firstrow, firstelem, nelem, strdata, status)) {
-        set_ioerr_string_from_status(*status);
+    if (NOGIL(fits_write_col_str(fits, colnum, firstrow, firstelem, nelem, strdata, status))) {
         free(strdata);
         return 1;
     }
@@ -1624,6 +1652,8 @@ int write_string_column(
 // You can append rows using firstrow = nrows+1
 static PyObject *
 PyFITSObject_write_column(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -1651,7 +1681,7 @@ PyFITSObject_write_column(struct PyFITSObject* self, PyObject* args, PyObject* k
     }
     firstrow = (LONGLONG) firstrow_py;
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1674,20 +1704,20 @@ PyFITSObject_write_column(struct PyFITSObject* self, PyObject* args, PyObject* k
     if (fits_dtype == TSTRING) {
 
         // this is my wrapper for strings
-        if (write_string_column(self->fits, colnum, firstrow, firstelem, nelem, data, &status)) {
+        if (NOGIL(write_string_column(self->fits, colnum, firstrow, firstelem, nelem, data, &status))) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
         
     } else {
-        if( fits_write_col(self->fits, fits_dtype, colnum, firstrow, firstelem, nelem, data, &status)) {
+        if (NOGIL(fits_write_col(self->fits, fits_dtype, colnum, firstrow, firstelem, nelem, data, &status))) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
     }
 
     // this is a full file close and reopen
-    if (fits_flush_file(self->fits, &status)) {
+    if (NOGIL(fits_flush_file(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1699,6 +1729,8 @@ PyFITSObject_write_column(struct PyFITSObject* self, PyObject* args, PyObject* k
 
 static PyObject *
 PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -1736,7 +1768,7 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
     }
     firstrow = (LONGLONG) firstrow_py;
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -1752,6 +1784,7 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
     }
     ncols = PyList_Size(colnum_list);
     if (ncols == 0) {
+        status = -1;
         goto _fitsio_pywrap_write_columns_bail;
     }
     if (ncols != PyList_Size(array_list)) {
@@ -1770,8 +1803,11 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
         npy_dtype = PyArray_TYPE(tmp_array);
         fits_dtypes[icol] = npy_to_fits_table_type(npy_dtype);
         if (fits_dtypes[icol] == -9999) {
-            status=1;
-            goto _fitsio_pywrap_write_columns_bail;
+            status=-1;
+            PyErr_Format(PyExc_ValueError,
+                    "data type not understodd, "
+                    "%td", icol);
+            goto _fitsio_pywrap_write_columns_bail1;
         }
 
         if (fits_dtypes[icol]==TSTRING) {
@@ -1787,8 +1823,8 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
                 PyErr_Format(PyExc_ValueError,
                         "not all entries have same row count, "
                         "%lld/%ld", nelem,dims[0]);
-                status=1;
-                goto _fitsio_pywrap_write_columns_bail;
+                status=-1;
+                goto _fitsio_pywrap_write_columns_bail1;
             }
         }
         if (is_string[icol]) {
@@ -1810,6 +1846,8 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
         //fprintf(stderr,"nperrow[%ld]: %ld\n", icol, (long)nperrow[icol]);
     }
 
+    {
+    Py_BEGIN_ALLOW_THREADS
     for (irow=0; irow<nelem; irow++) {
         thisrow = firstrow + irow;
         for (icol=0; icol<ncols; icol++) {
@@ -1822,7 +1860,6 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
                                         nperrow[icol], 
                                         (char*)data, 
                                         &status)) {
-                    set_ioerr_string_from_status(status);
                     goto _fitsio_pywrap_write_columns_bail;
                 }
                 /*
@@ -1852,7 +1889,6 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
                                    nperrow[icol], 
                                    data, 
                                    &status)) {
-                    set_ioerr_string_from_status(status);
                     goto _fitsio_pywrap_write_columns_bail;
                 }
             }
@@ -1882,14 +1918,18 @@ PyFITSObject_write_columns(struct PyFITSObject* self, PyObject* args, PyObject* 
         return NULL;
     }
     */
-
 _fitsio_pywrap_write_columns_bail:
+    Py_END_ALLOW_THREADS
+    }
+_fitsio_pywrap_write_columns_bail1:
     free(is_string); is_string=NULL;
     free(colnums); colnums=NULL;
     free(array_ptrs); array_ptrs=NULL;
     free(nperrow); nperrow=NULL;
     free(fits_dtypes); fits_dtypes=NULL;
-    if (status != 0) {
+    if (status > 0) {
+        /* negative is our errors */
+        set_ioerr_string_from_status(status);
         return NULL;
     }
     Py_RETURN_NONE;
@@ -1910,6 +1950,7 @@ int write_var_string_column(
         LONGLONG  firstrow,  /* I - first row to write (1 = 1st row)        */
         PyObject* array,
         int  *status) {   /* IO - error status                           */
+    ALLOW_NOGIL
 
     LONGLONG firstelem=1; // ignored
     LONGLONG nelem=1; // ignored
@@ -1932,9 +1973,9 @@ int write_var_string_column(
 
         // just a container
         strarr[0] = strdata;
-        res=fits_write_col_str(fits, colnum, 
+        res=NOGIL(fits_write_col_str(fits, colnum, 
                                firstrow+i, firstelem, nelem, 
-                               strarr, status);
+                               strarr, status));
 
         free(strdata);
         if(res > 0) {
@@ -2002,8 +2043,8 @@ int write_var_num_column(
 
         nelem=PyArray_SIZE(el);
         data=PyArray_DATA(el_array);
-        res=fits_write_col(fits, abs(fits_dtype), colnum, 
-                           firstrow+i, firstelem, (LONGLONG) nelem, data, status);
+        res=NOGIL(fits_write_col(fits, abs(fits_dtype), colnum, 
+                           firstrow+i, firstelem, (LONGLONG) nelem, data, status));
         Py_XDECREF(el_array);
 
         if(res > 0) {
@@ -2029,6 +2070,8 @@ int write_var_num_column(
 
 static PyObject *
 PyFITSObject_write_var_column(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -2053,7 +2096,7 @@ PyFITSObject_write_var_column(struct PyFITSObject* self, PyObject* args, PyObjec
     }
     firstrow = (LONGLONG) firstrow_py;
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2072,7 +2115,7 @@ PyFITSObject_write_var_column(struct PyFITSObject* self, PyObject* args, PyObjec
 
     // determine the fits dtype for this column.  We will use this to get data
     // from the array for writing
-    if (fits_get_eqcoltypell(self->fits, colnum, &fits_dtype, NULL, NULL, &status) > 0) {
+    if (NOGIL(fits_get_eqcoltypell(self->fits, colnum, &fits_dtype, NULL, NULL, &status)) > 0) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2092,7 +2135,7 @@ PyFITSObject_write_var_column(struct PyFITSObject* self, PyObject* args, PyObjec
     }
 
     // this is a full file close and reopen
-    if (fits_flush_file(self->fits, &status)) {
+    if (NOGIL(fits_flush_file(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2107,6 +2150,8 @@ PyFITSObject_write_var_column(struct PyFITSObject* self, PyObject* args, PyObjec
 // let python do the conversions
 static PyObject *
 PyFITSObject_write_string_key(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -2115,7 +2160,7 @@ PyFITSObject_write_string_key(struct PyFITSObject* self, PyObject* args) {
     char* value=NULL;
     char* comment=NULL;
     char* comment_in=NULL;
- 
+
     if (!PyArg_ParseTuple(args, (char*)"isss", &hdunum, &keyname, &value, &comment_in)) {
         return NULL;
     }
@@ -2124,7 +2169,7 @@ PyFITSObject_write_string_key(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2133,13 +2178,13 @@ PyFITSObject_write_string_key(struct PyFITSObject* self, PyObject* args) {
         comment=comment_in;
     }
 
-    if (fits_update_key_str(self->fits, keyname, value, comment, &status)) {
+    if (NOGIL(fits_update_key_str(self->fits, keyname, value, comment, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
     // this does not close and reopen
-    if (fits_flush_buffer(self->fits, 0, &status)) {
+    if (NOGIL(fits_flush_buffer(self->fits, 0, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2149,6 +2194,8 @@ PyFITSObject_write_string_key(struct PyFITSObject* self, PyObject* args) {
  
 static PyObject *
 PyFITSObject_write_double_key(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL 
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -2168,7 +2215,7 @@ PyFITSObject_write_double_key(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2177,13 +2224,13 @@ PyFITSObject_write_double_key(struct PyFITSObject* self, PyObject* args) {
         comment=comment_in;
     }
 
-    if (fits_update_key_dbl(self->fits, keyname, value, decimals, comment, &status)) {
+    if (NOGIL(fits_update_key_dbl(self->fits, keyname, value, decimals, comment, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
     // this does not close and reopen
-    if (fits_flush_buffer(self->fits, 0, &status)) {
+    if (NOGIL(fits_flush_buffer(self->fits, 0, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2194,6 +2241,8 @@ PyFITSObject_write_double_key(struct PyFITSObject* self, PyObject* args) {
  
 static PyObject *
 PyFITSObject_write_long_key(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL 
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -2202,7 +2251,7 @@ PyFITSObject_write_long_key(struct PyFITSObject* self, PyObject* args) {
     long value=0;
     char* comment=NULL;
     char* comment_in=NULL;
- 
+
     if (!PyArg_ParseTuple(args, (char*)"isls", &hdunum, &keyname, &value, &comment_in)) {
         return NULL;
     }
@@ -2211,7 +2260,7 @@ PyFITSObject_write_long_key(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2298,13 +2347,13 @@ PyFITSObject_write_comment(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_write_comment(self->fits, comment, &status)) {
+    if (NOGIL(fits_write_comment(self->fits, comment, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
     // this does not close and reopen
-    if (fits_flush_buffer(self->fits, 0, &status)) {
+    if (NOGIL(fits_flush_buffer(self->fits, 0, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2396,8 +2445,7 @@ static int read_ascii_column_all(fitsfile* fits, int colnum, PyObject* array, in
 
         strdata=malloc(nelem*sizeof(char*));
         if (NULL==strdata) {
-            PyErr_SetString(PyExc_MemoryError, "could not allocate temporary string pointers");
-            *status = 99;
+            *status = 113;
             return 1;
 
         }
@@ -2410,7 +2458,7 @@ static int read_ascii_column_all(fitsfile* fits, int colnum, PyObject* array, in
             strdata[i] = (char*) PyArray_GETPTR1(array, i);
         }
 
-        if (fits_read_col_str(fits,colnum,firstrow,firstelem,nelem,nulstr,strdata,anynul,status) > 0) {
+        if (NOGIL(fits_read_col_str(fits,colnum,firstrow,firstelem,nelem,nulstr,strdata,anynul,status)) > 0) {
             free(strdata);
             return 1;
         }
@@ -2420,7 +2468,7 @@ static int read_ascii_column_all(fitsfile* fits, int colnum, PyObject* array, in
 
     } else {
         data=PyArray_DATA(array);
-        if (fits_read_col(fits,fits_dtype,colnum,firstrow,firstelem,nelem,nulval,data,anynul,status) > 0) {
+        if (NOGIL(fits_read_col(fits,fits_dtype,colnum,firstrow,firstelem,nelem,nulval,data,anynul,status)) > 0) {
             return 1;
         }
     }
@@ -2430,6 +2478,7 @@ static int read_ascii_column_all(fitsfile* fits, int colnum, PyObject* array, in
 }
 static int read_ascii_column_byrow(
         fitsfile* fits, int colnum, PyObject* array, PyObject* rowsObj, int* status) {
+    ALLOW_NOGIL
 
     int npy_dtype=0;
     int fits_dtype=0;
@@ -2476,11 +2525,11 @@ static int read_ascii_column_byrow(
         data = PyArray_GETPTR1(array, i);
         if (fits_dtype==TSTRING) {
             cdata = (char* ) data;
-            if (fits_read_col_str(fits,colnum,rownum,firstelem,1,nulstr,&cdata,anynul,status) > 0) {
+            if (NOGIL(fits_read_col_str(fits,colnum,rownum,firstelem,1,nulstr,&cdata,anynul,status)) > 0) {
                 return 1;
             }
         } else {
-            if (fits_read_col(fits,fits_dtype,colnum,rownum,firstelem,1,nulval,data,anynul,status) > 0) {
+            if (NOGIL(fits_read_col(fits,fits_dtype,colnum,rownum,firstelem,1,nulval,data,anynul,status)) > 0) {
                 return 1;
             }
         }
@@ -2566,6 +2615,8 @@ static int read_binary_column(
  */
 static PyObject *
 PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
     int colnum=0;
@@ -2585,7 +2636,7 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2603,6 +2654,7 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
 
     
     if (hdutype == ASCII_TBL) {
+        /* This needs the GIL */
         if (read_ascii_column(self->fits, colnum, array, rowsObj, &status)) {
             set_ioerr_string_from_status(status);
             return NULL;
@@ -2619,7 +2671,7 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
             rows = get_int64_from_array(rowsObj, &nrows);
         }
 
-        if (read_binary_column(self->fits, colnum, nrows, rows, data, stride, &status)) {
+        if (NOGIL(read_binary_column(self->fits, colnum, nrows, rows, data, stride, &status))) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
@@ -2645,6 +2697,8 @@ static void free_all_python_list(PyObject* list) {
 
 static PyObject*
 read_var_string(fitsfile* fits, int colnum, LONGLONG row, LONGLONG nchar, int* status) {
+    ALLOW_NOGIL
+
     LONGLONG firstelem=1;
     char* str=NULL;
     char* strarr[1];
@@ -2660,7 +2714,7 @@ read_var_string(fitsfile* fits, int colnum, LONGLONG row, LONGLONG nchar, int* s
     }
 
     strarr[0] = str;
-    if (fits_read_col(fits,TSTRING,colnum,row,firstelem,nchar,nulval,strarr,anynul,status) > 0) {
+    if (NOGIL(fits_read_col(fits,TSTRING,colnum,row,firstelem,nchar,nulval,strarr,anynul,status)) > 0) {
         goto read_var_string_cleanup;
     }
 #if PY_MAJOR_VERSION >= 3
@@ -2683,6 +2737,8 @@ read_var_string_cleanup:
 static PyObject*
 read_var_nums(fitsfile* fits, int colnum, LONGLONG row, LONGLONG nelem, 
               int fits_dtype, int npy_dtype, int* status) {
+    ALLOW_NOGIL
+
     LONGLONG firstelem=1;
     PyObject* arrayObj=NULL;
     void* nulval=0;
@@ -2690,7 +2746,6 @@ read_var_nums(fitsfile* fits, int colnum, LONGLONG row, LONGLONG nelem,
     npy_intp dims[1];
     int fortran=0;
     void* data=NULL;
-
 
     dims[0] = nelem;
     arrayObj=PyArray_ZEROS(1, dims, npy_dtype, fortran);
@@ -2700,7 +2755,7 @@ read_var_nums(fitsfile* fits, int colnum, LONGLONG row, LONGLONG nelem,
         return NULL;
     }
     data = PyArray_DATA(arrayObj);
-    if (fits_read_col(fits,abs(fits_dtype),colnum,row,firstelem,nelem,nulval,data,anynul,status) > 0) {
+    if (NOGIL(fits_read_col(fits,abs(fits_dtype),colnum,row,firstelem,nelem,nulval,data,anynul,status)) > 0) {
         Py_XDECREF(arrayObj);
         return NULL;
     }
@@ -2713,6 +2768,8 @@ read_var_nums(fitsfile* fits, int colnum, LONGLONG row, LONGLONG nelem,
  */
 static PyObject *
 PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int colnum=0;
     PyObject* rowsObj=NULL;
@@ -2745,7 +2802,7 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2755,13 +2812,13 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
         return NULL;
     }
     // using struct defs here, could cause problems
-    fits_get_num_cols(self->fits, &ncols, &status);
+    NOGIL(fits_get_num_cols(self->fits, &ncols, &status));
     if (colnum < 1 || colnum > ncols) {
         PyErr_SetString(PyExc_RuntimeError, "requested column is out of bounds");
         return NULL;
     }
 
-    if (fits_get_coltypell(self->fits, colnum, &fits_dtype, &repeat, &width, &status) > 0) {
+    if (NOGIL(fits_get_coltypell(self->fits, colnum, &fits_dtype, &repeat, &width, &status)) > 0) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -2776,7 +2833,7 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
     }
     
     if (rowsObj == Py_None) {
-        fits_get_num_rowsll(self->fits, &nrows, &tstatus);
+        NOGIL(fits_get_num_rowsll(self->fits, &nrows, &tstatus));
         get_all_rows=1;
     } else {
         npy_intp tnrows=0;
@@ -2797,7 +2854,7 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
         }
 
         // repeat holds how many elements are in this row
-        if (fits_read_descriptll(self->fits, colnum, row, &repeat, &offset, &status) > 0) {
+        if (NOGIL(fits_read_descriptll(self->fits, colnum, row, &repeat, &offset, &status)) > 0) {
             goto read_var_column_cleanup;
         }
 
@@ -2895,6 +2952,8 @@ static int read_binary_rec_columns(
 // python method for reading specified columns and rows
 static PyObject *
 PyFITSObject_read_columns_as_rec(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
     npy_intp ncols=0;
@@ -2917,7 +2976,7 @@ PyFITSObject_read_columns_as_rec(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         goto recread_columns_cleanup;
     }
 
@@ -2940,7 +2999,7 @@ PyFITSObject_read_columns_as_rec(struct PyFITSObject* self, PyObject* args) {
     } else {
         rows = get_int64_from_array(rowsobj, &nrows);
     }
-    if (read_binary_rec_columns(self->fits, ncols, colnums, nrows, rows, data, &status)) {
+    if (NOGIL(read_binary_rec_columns(self->fits, ncols, colnums, nrows, rows, data, &status))) {
         goto recread_columns_cleanup;
     }
 
@@ -3041,6 +3100,8 @@ static int read_columns_as_rec_byoffset(
  */
 static PyObject *
 PyFITSObject_read_columns_as_rec_byoffset(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -3068,7 +3129,7 @@ PyFITSObject_read_columns_as_rec_byoffset(struct PyFITSObject* self, PyObject* a
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         goto recread_columns_byoffset_cleanup;
     }
 
@@ -3100,14 +3161,14 @@ PyFITSObject_read_columns_as_rec_byoffset(struct PyFITSObject* self, PyObject* a
 
     data = PyArray_DATA(array);
     recsize = PyArray_ITEMSIZE(array);
-    if (read_columns_as_rec_byoffset(
+    if (NOGIL(read_columns_as_rec_byoffset(
                 self->fits, 
                 ncols, colnums, offsets,
                 nrows, 
                 rows, 
                 (char*) data, 
                 recsize,
-                &status) > 0) {
+                &status)) > 0) {
         goto recread_columns_byoffset_cleanup;
     }
 
@@ -3198,6 +3259,8 @@ static int read_rec_bytes_byrowold(
 // python method to read all columns but subset of rows
 static PyObject *
 PyFITSObject_read_rows_as_rec(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
 
@@ -3217,7 +3280,7 @@ PyFITSObject_read_rows_as_rec(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         goto recread_byrow_cleanup;
     }
 
@@ -3233,7 +3296,7 @@ PyFITSObject_read_rows_as_rec(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
  
-    if (read_rec_bytes_byrow(self->fits, nrows, rows, data, &status)) {
+    if (NOGIL(read_rec_bytes_byrow(self->fits, nrows, rows, data, &status))) {
         goto recread_byrow_cleanup;
     }
 
@@ -3273,6 +3336,8 @@ static int read_rec_range(fitsfile* fits, LONGLONG firstrow, LONGLONG nrows, voi
 /* here rows are 1-offset, unlike when reading a specific subset of rows */
 static PyObject *
 PyFITSObject_read_as_rec(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
 
@@ -3292,7 +3357,7 @@ PyFITSObject_read_as_rec(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         goto recread_asrec_cleanup;
     }
 
@@ -3304,7 +3369,7 @@ PyFITSObject_read_as_rec(struct PyFITSObject* self, PyObject* args) {
     data = PyArray_DATA(array);
 
     nrows=lastrow-firstrow+1;
-    if (read_rec_range(self->fits, (LONGLONG)firstrow, (LONGLONG)nrows, data, &status)) {
+    if (NOGIL(read_rec_range(self->fits, (LONGLONG)firstrow, (LONGLONG)nrows, data, &status))) {
         goto recread_asrec_cleanup;
     }
 
@@ -3323,6 +3388,8 @@ recread_asrec_cleanup:
 // Note numpy allows a maximum of 32 dimensions
 static PyObject *
 PyFITSObject_read_image(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
     int status=0;
@@ -3350,12 +3417,12 @@ PyFITSObject_read_image(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         return NULL;
     }
 
-    if (fits_get_img_paramll(self->fits, maxdim, &datatype, &naxis, 
-                             naxes, &status)) {
+    if (NOGIL(fits_get_img_paramll(self->fits, maxdim, &datatype, &naxis, 
+                             naxes, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -3382,8 +3449,8 @@ PyFITSObject_read_image(struct PyFITSObject* self, PyObject* args) {
     for (i=0; i<naxis; i++) {
         firstpixels[i] = 1;
     }
-    if (fits_read_pixll(self->fits, fits_read_dtype, firstpixels, size,
-                        0, data, &anynul, &status)) {
+    if (NOGIL(fits_read_pixll(self->fits, fits_read_dtype, firstpixels, size,
+                        0, data, &anynul, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -3433,6 +3500,8 @@ static int get_long_slices(PyObject* fpix_arr,
 // of the input array is done.
 static PyObject *
 PyFITSObject_read_image_slice(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int hdunum=0;
     int hdutype=0;
     int status=0;
@@ -3455,7 +3524,7 @@ PyFITSObject_read_image_slice(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         return NULL;
     }
 
@@ -3468,8 +3537,8 @@ PyFITSObject_read_image_slice(struct PyFITSObject* self, PyObject* args) {
     npy_dtype = PyArray_TYPE(array);
     npy_to_fits_image_types(npy_dtype, &dummy, &fits_read_dtype);
 
-    if (fits_read_subset(self->fits, fits_read_dtype, fpix, lpix, step,
-                         0, data, &anynul, &status)) {
+    if (NOGIL(fits_read_subset(self->fits, fits_read_dtype, fpix, lpix, step,
+                         0, data, &anynul, &status))) {
         set_ioerr_string_from_status(status);
         goto read_image_slice_cleanup;
     }
@@ -3493,6 +3562,8 @@ read_image_slice_cleanup:
 // card
 static PyObject *
 PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -3507,7 +3578,6 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
     PyObject* list=NULL;
     PyObject* dict=NULL;  // to hold the dict for each record
 
-
     if (!PyArg_ParseTuple(args, (char*)"i", &hdunum)) {
         return NULL;
     }
@@ -3516,12 +3586,12 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
         PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
         return NULL;
     }
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
-    if (fits_get_hdrspace(self->fits, &nkeys, &morekeys, &status)) {
+    if (NOGIL(fits_get_hdrspace(self->fits, &nkeys, &morekeys, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -3530,7 +3600,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
     for (i=0; i<nkeys; i++) {
 
         // the full card
-        if (fits_read_record(self->fits, i+1, card, &status)) {
+        if (NOGIL(fits_read_record(self->fits, i+1, card, &status))) {
             // is this enough?
             Py_XDECREF(list);
             set_ioerr_string_from_status(status);
@@ -3539,7 +3609,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
 
         // this just returns the character string stored in the header; we
         // can eval in python
-        if (fits_read_keyn(self->fits, i+1, keyname, value, comment, &status)) {
+        if (NOGIL(fits_read_keyn(self->fits, i+1, keyname, value, comment, &status))) {
             // is this enough?
             Py_XDECREF(list);
             set_ioerr_string_from_status(status);
@@ -3563,6 +3633,8 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
  
 static PyObject *
 PyFITSObject_write_checksum(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -3576,16 +3648,16 @@ PyFITSObject_write_checksum(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
-    if (fits_write_chksum(self->fits, &status)) {
+    if (NOGIL(fits_write_chksum(self->fits, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
-    if (fits_get_chksum(self->fits, &datasum, &hdusum, &status)) {
+    if (NOGIL(fits_get_chksum(self->fits, &datasum, &hdusum, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -3598,6 +3670,8 @@ PyFITSObject_write_checksum(struct PyFITSObject* self, PyObject* args) {
 }
 static PyObject *
 PyFITSObject_verify_checksum(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -3610,12 +3684,12 @@ PyFITSObject_verify_checksum(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
 
-    if (fits_verify_chksum(self->fits, &dataok, &hduok, &status)) {
+    if (NOGIL(fits_verify_chksum(self->fits, &dataok, &hduok, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -3631,6 +3705,8 @@ PyFITSObject_verify_checksum(struct PyFITSObject* self, PyObject* args) {
 
 static PyObject *
 PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
+    ALLOW_NOGIL
+
     int status=0;
     int hdunum=0;
     int hdutype=0;
@@ -3650,12 +3726,11 @@ PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
     npy_intp* data=NULL;
     long i=0;
 
-
     if (!PyArg_ParseTuple(args, (char*)"is", &hdunum, &expression)) {
         return NULL;
     }
 
-    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+    if (NOGIL(fits_movabs_hdu(self->fits, hdunum, &hdutype, &status))) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -3671,7 +3746,7 @@ PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_find_rows(self->fits, expression, firstrow, (long) nrows, &ngood, row_status, &status)) {
+    if (NOGIL(fits_find_rows(self->fits, expression, firstrow, (long) nrows, &ngood, row_status, &status))) {
         set_ioerr_string_from_status(status);
         goto where_function_cleanup;
     }
@@ -3686,12 +3761,14 @@ PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
     if (ngood > 0) {
         data = PyArray_DATA(indicesObj);
 
+        Py_BEGIN_ALLOW_THREADS
         for (i=0; i<nrows; i++) {
             if (row_status[i]) {
                 *data = (npy_intp) i;
                 data++;
             }
         }
+        Py_END_ALLOW_THREADS
     }
 where_function_cleanup:
     free(row_status);

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -2611,7 +2611,8 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
         void* data=PyArray_DATA(array);
         npy_intp nrows=0;
         npy_int64* rows=NULL;
-        npy_intp stride=PyArray_STRIDE(array,0);
+        npy_intp * strides=PyArray_STRIDES(array);
+        npy_intp stride = strides?strides[0]:0;
         if (rowsObj == Py_None) {
             nrows = hdu->numrows;
         } else {

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -3153,7 +3153,7 @@ class TableColumnSubset(object):
 
         for colnum,c in enumerate(info['colinfo']):
             if isstring(self.columns):
-                if c['name'] == self.columns:
+                if c['name'] != self.columns:
                     continue
             else:
                 if c['name'] not in self.columns:

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -23,10 +23,10 @@ See the main docs at https://github.com/esheldon/fitsio
 from __future__ import with_statement, print_function
 import sys, os
 import numpy
-from . import _fitsio_wrap
 import copy
 import pprint
 
+import _fitsio_wrap
 def cfitsio_version(asfloat=False):
     """
     Return the cfitsio version as a string.

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -3152,8 +3152,12 @@ class TableColumnSubset(object):
         pformat = cspacing + "%-" + str(nname) + "s\n %" + str(nspace+nname+ntype) + "s  %s"
 
         for colnum,c in enumerate(info['colinfo']):
-            if c['name'] not in self.columns:
-                continue
+            if isstring(self.columns):
+                if c['name'] == self.columns:
+                    continue
+            else:
+                if c['name'] not in self.columns:
+                    continue
 
             if len(c['name']) > nname:
                 f = pformat

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -311,7 +311,7 @@ class FITS(object):
             if clobber:
                 create=1
                 if os.path.exists(filename):
-                    print('Removing existing file')
+                    # print('Removing existing file')
                     os.remove(filename)
             else:
                 if os.path.exists(filename):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def copy_update(dir1,dir2):
 
 def configure_cfitsio():
     os.chdir(cfitsio_build_dir)
-    ret=os.system('sh ./configure')
+    ret=os.system('sh ./configure  --enable-reentrant')
     if ret != 0:
         raise ValueError("could not configure cfitsio %s" % cfitsio_version)
     os.chdir(package_basedir)


### PR DESCRIPTION
Trying to read the SDSS spectra files with fitsio and noticed a few weirdness:

The DR10 Spectra's doesn't have Z_PERSON. But in the repr of fits[2]['Z_PERSON'] 
I see subcolumn 'Z'.
The first commit fixes this. Is is because when ColumnSubset.columns is scalar and improperly handled.

The second commit fixes a core dump when I run
fits[2]['CLASS_PERSON']['CLASS'][:]
It is because when the target is a scalar, strides is NULL and PyArray_STRIDE, core dumps. The fact that array is a numpy scalar is probably also worrisome; but with this modification the code gives the correct result 'QSO' without core dumps.

Another commit disables printing to stdout. Because printing to stdout from a library will mess up with regular outputs from the programs using the library. issuing python warnings might be more appropriate.

Another commit disables explicit relative imports. Python by default looks for modules in . first, thus there is no need to explicitly declear '.' in the imports.

