### PR TITLE
Support more ascii column types

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -3885,8 +3885,8 @@ _table_fits2npy_ascii = {16: 'S',
                          31: 'i8', # listed as TINT, reading as i8
                          41: 'i8', # listed as TLONG, reading as i8
                          81: 'i8',
-                         21: 'i8',
-                         42: 'f8',
+                         21: 'i4', # listed as TSHORT, reading as i4
+                         42: 'f8', # listed as TFLOAT, reading as f8
                          82: 'f8'}
 
 


### PR DESCRIPTION
When reading ascii tables some columns are not supported. This change supports TSHORT and TFLOAT column types.
