### PR TITLE
Adding fix when iter_row_buffer exceeds number of rows in table.

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1288,6 +1288,9 @@ class TableHDU(HDUBase):
         self.case_sensitive=keys.get('case_sensitive',False)
         self._iter_row_buffer=keys.get('iter_row_buffer',1)
 
+        if self._iter_row_buffer > self.get_nrows:
+        	self._iter_row_buffer = self.get_nrows
+
         if self._info['hdutype'] == ASCII_TBL:
             self._table_type_str='ascii'
         else:


### PR DESCRIPTION
Given this example:

```
fits=fitsio.FITS(filename,iter_row_buffer=1000)
for row in fits[1]:
    print row
```

If the number of rows in the table exceeds the specified buffer, this leads to the following crash:

```
Traceback (most recent call last):
  File "script.py", line 102, in <module>
    for row in photoFieldFile.dataHDU:
  File "/sys/pkg/python/2.7.3_rhel6/lib/python2.7/site-packages/fitsio/fitslib.py", line 1828, in __getitem__
    array = self.read(rows=res)
  File "/sys/pkg/python/2.7.3_rhel6/lib/python2.7/site-packages/fitsio/fitslib.py", line 1623, in read
    data = self.read_rows(rows, **keys)
  File "/sys/pkg/python/2.7.3_rhel6/lib/python2.7/site-packages/fitsio/fitslib.py", line 2026, in read_rows
    rows = self._extract_rows(rows)
  File "/sys/pkg/python/2.7.3_rhel6/lib/python2.7/site-packages/fitsio/fitslib.py", line 2311, in _extract_rows
    raise ValueError("rows must be in [%d,%d]" % (0,maxrow))
ValueError: rows must be in [0,174]
```
