### PR TITLE
must pop() header kwargs, or ImageHDU.read() chokes

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -88,7 +88,7 @@ def read(filename, ext=None, extver=None, **keys):
 
     with FITS(filename, **keys) as fits:
 
-        header=keys.get('header',False)
+        header=keys.pop('header',False)
 
         if ext is None:
             for i in xrange(len(fits)):


### PR DESCRIPTION
I encountered this when reading an image and header via:

python -c "import fitsio; fitsio.read('wise-frames/6a/03406a/221/03406a221-w3-int-1b.fits', header=True)"

The ImageHDU class's read() method does not accept kwargs, so we have to pop off the header= kwargs first.
