### PR TITLE
fix bug in unittest script

### DIFF
--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -24,7 +24,7 @@ class TestReadWrite(unittest.TestCase):
         # all currently available types, scalar, 1-d and 2-d array columns
         dtype=[('u1scalar','u1'),
                ('i1scalar','i1'),
-               ('b1scalar','b1'),
+               ('b1scalar','b'),
                ('u2scalar','u2'),
                ('i2scalar','i2'),
                ('u4scalar','u4'),
@@ -37,7 +37,7 @@ class TestReadWrite(unittest.TestCase):
 
                ('u1vec','u1',nvec),
                ('i1vec','i1',nvec),
-               ('b1vec','b1',nvec),
+               ('b1vec','b',nvec),
                ('u2vec','u2',nvec),
                ('i2vec','i2',nvec),
                ('u4vec','u4',nvec),
@@ -50,7 +50,7 @@ class TestReadWrite(unittest.TestCase):
  
                ('u1arr','u1',ashape),
                ('i1arr','i1',ashape),
-               ('b1arr','b1',ashape),
+               ('b1arr','b',ashape),
                ('u2arr','u2',ashape),
                ('i2arr','i2',ashape),
                ('u4arr','u4',ashape),


### PR DESCRIPTION
It appears that some versions of numpy do not like the dtype string `'b1'` which causes the unittests to fail incorrectly. (Note that `'b'` in numpy is defined to be 1 byte long, so `'b1'` is redundant in some sense, not that this matters.) When I declare an array with type `'b1'` with my numpy 1.9.0 I get back

``` python
In [5]: d = np.zeros(1,dtype=[('logical','b1')])
In [6]: d.dtype
Out[6]: dtype([('logical', '?')])
```

The `'?'` indicates a problem. 

When setting `'b1'` to `'b'`, I get

``` python
In [7]: d = np.zeros(1,dtype=[('logical','b')])
In [8]: d.dtype
Out[8]: dtype([('logical', 'i1')])
```

which defaults to the correct type. 

With this change, all of the unittests pass.
