### PR TITLE
enabled setup to use system cfitsio

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,10 @@ New Featurees
         by SCAMP and return a FITSHDR object
     - reserved header space when creating image and table extensions
         and a header is being written.  This can improve performance
-        substantially on distributed file systems.
+        substantially, especially on distributed file systems.
     - When possible write image data at HDU creation.  This can
-        be a big performance improvement on distributed file systems.
+        be a big performance improvement, especially on distributed file
+        systems.
 
 Bug Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@ New Featurees
 
     - added read_scamp_head function to read the .head files output
         by SCAMP and return a FITSHDR object
+    - reserved header space when creating image and table extensions
+        and a header is being written.  This can improve performance
+        substantially on distributed file systems.
+    - When possible write image data at HDU creation.  This can
+        be a big performance improvement on distributed file systems.
 
 Bug Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+version 0.9.8 (not yet released)
+----------------------------------
+
+New Featurees
+
+    - added read_scamp_head function to read the .head files output
+        by SCAMP and return a FITSHDR object
+
+Bug Fixes
+
+    - Fixed broken boolean fields in new versions of numpy (rainwoodman)
+    - removed -iarch in setup.py for mac OS X.  This should
+        work for versions Mavericks and Snow Leapard (Christopher Bonnett)
+
 version 0.9.7
 ----------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 version 0.9.8 (not yet released)
 ----------------------------------
 
-New Featurees
+New Features
 
     - added read_scamp_head function to read the .head files output
         by SCAMP and return a FITSHDR object

--- a/fitsio/__init__.py
+++ b/fitsio/__init__.py
@@ -4,7 +4,7 @@ See the docs at https://github.com/esheldon/fitsio for example
 usage.
 """
 
-__version__='0.9.7'
+__version__='0.9.8rc1'
 
 from . import fitslib
 from . import util

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1175,12 +1175,18 @@ static int pyarray_get_ndim(PyObject* obj) {
 }
 
 /*
- * It is useful to create the extension first so we can write keywords into the
- * header before adding data.  This avoids moving the data if the header grows
- * too large.
- *
- * also we allow creating from dimensions rather than from the input image shape,
- * writing into the HDU later
+   Create an image extension, possible writing data as well.
+
+   We allow creating from dimensions rather than from the input image shape,
+   writing into the HDU later
+
+   It is useful to create the extension first so we can write keywords into the
+   header before adding data.  This avoids moving the data if the header grows
+   too large.
+
+   However, on distributed file systems it can be more efficient to write
+   the data at this time due to slowness with updating the file in place.
+
  */
 
 static PyObject *

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -530,8 +530,8 @@ class FITS(object):
             self[-1].write_keys(header)
             self[-1]._update_info()
 
-        if img is not None:
-            self[-1].write(img)
+        #if img is not None:
+        #    self[-1].write(img)
 
 
     def create_image_hdu(self,
@@ -550,6 +550,8 @@ class FITS(object):
             fits.create_image_hdu(image, ...)
             fits.create_image_hdu(dims=dims, dtype=dtype)
 
+        If an image is sent, the data are also written.
+
         You can write data into the new extension using
             fits[extension].write(image)
 
@@ -560,12 +562,13 @@ class FITS(object):
             fits.write_image(image)
 
         which will create the new image extension for you with the appropriate
-        structure.
+        structure, and write the data.
 
         parameters
         ----------
         img: ndarray, optional
-            An image with which to determine the properties of the HDU
+            An image with which to determine the properties of the HDU. The
+            data will be written.
         dims: sequence, optional
             A sequence describing the dimensions of the image to be created
             on disk.  You must also send a dtype=

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -521,7 +521,9 @@ class FITS(object):
         The File must be opened READWRITE
         """
 
-        self.create_image_hdu(img, extname=extname, extver=extver,
+        self.create_image_hdu(img, 
+                              header=header,
+                              extname=extname, extver=extver,
                               compress=compress, tile_dims=tile_dims)
 
         if header is not None:
@@ -539,7 +541,8 @@ class FITS(object):
                          extname=None,
                          extver=None,
                          compress=None,
-                         tile_dims=None):
+                         tile_dims=None,
+                         header=None):
         """
         Create a new, empty image HDU and reload the hdu list.  Either
         create from an input image or from input dims and dtype
@@ -589,13 +592,8 @@ class FITS(object):
             (case-insensitive) See the cfitsio manual for details.
 
         header: FITSHDR, list, dict, optional
-            A set of header keys to write. Can be one of these:
-                - FITSHDR object
-                - list of dictionaries containing 'name','value' and optionally
-                  a 'comment' field.
-                - a dictionary of keyword-value pairs; no comments are written
-                  in this case, and the order is arbitrary
-            Note required keywords such as NAXIS, XTENSION, etc are cleaed out.
+            This is only used to determine how many slots to reserve for
+            header keywords
 
 
         restrictions
@@ -655,7 +653,13 @@ class FITS(object):
         if img2send is not None:
             check_comptype_img(comptype, dtstr)
 
+        if header is not None:
+            nkeys=len(header)
+        else:
+            nkeys=0
+
         self._FITS.create_image_hdu(img2send,
+                                    nkeys,
                                     dims=dims2send,
                                     comptype=comptype, 
                                     tile_dims=tile_dims,
@@ -736,6 +740,7 @@ class FITS(object):
         """
 
         self.create_table_hdu(data=data, 
+                              header=header,
                               names=names,
                               units=units, 
                               extname=extname,
@@ -749,6 +754,7 @@ class FITS(object):
         self[-1].write(data,names=names)
 
     def create_table_hdu(self, data=None, dtype=None, 
+                         header=None,
                          names=None, formats=None,
                          units=None, dims=None, extname=None, extver=None, 
                          table_type='binary'):
@@ -815,6 +821,11 @@ class FITS(object):
             be an integer > 0.  If extver is not sent, the first one will be
             selected.  If ext is an integer, the extver is ignored.
 
+        header: FITSHDR, list, dict, optional
+            This is only used to determine how many slots to reserve for
+            header keywords
+
+
         restrictions
         ------------
         The File must be opened READWRITE
@@ -866,8 +877,13 @@ class FITS(object):
             # will be ignored
             extname=""
 
+        if header is not None:
+            nkeys=len(header)
+        else:
+            nkeys=0
+
         # note we can create extname in the c code for tables, but not images
-        self._FITS.create_table_hdu(table_type_int,
+        self._FITS.create_table_hdu(table_type_int, nkeys,
                                     names, formats, tunit=units, tdim=dims, 
                                     extname=extname, extver=extver)
 

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -161,6 +161,14 @@ def read_scamp_head(fname, header=None):
 
     return hdr
 
+def _make_item(ext, extver=None):
+    if extver is not None:
+        # e
+        item=(ext,extver)
+    else:
+        item=ext
+
+    return item
 
 def write(filename, data, extname=None, extver=None, units=None, 
           compress=None, table_type='binary', header=None, 

--- a/setup.py
+++ b/setup.py
@@ -1,95 +1,112 @@
 import distutils
 from distutils.core import setup, Extension, Command
 import os
+import sys
 import numpy
 import glob
 import shutil
 import platform
 
-package_basedir = os.path.abspath(os.curdir)
+if "--use-system-fitsio" not in sys.argv:
+    compile_fitsio_package = True
+else:
+    compile_fitsio_package = False
+    sys.argv.remove("--use-system-fitsio")
 
-#cfitsio_version = '3280patch'
-cfitsio_version = '3370'
-cfitsio_dir = 'cfitsio%s' % cfitsio_version
-cfitsio_build_dir = os.path.join('build',cfitsio_dir)
-cfitsio_zlib_dir = os.path.join(cfitsio_build_dir,'zlib')
+if compile_fitsio_package:
+    package_basedir = os.path.abspath(os.curdir)
 
-makefile = os.path.join(cfitsio_build_dir, 'Makefile')
+    #cfitsio_version = '3280patch'
+    cfitsio_version = '3370'
+    cfitsio_dir = 'cfitsio%s' % cfitsio_version
+    cfitsio_build_dir = os.path.join('build',cfitsio_dir)
+    cfitsio_zlib_dir = os.path.join(cfitsio_build_dir,'zlib')
+    
+    makefile = os.path.join(cfitsio_build_dir, 'Makefile')
 
-def copy_update(dir1,dir2):
-    f1 = os.listdir(dir1)
-    for f in f1:
-        path1 = os.path.join(dir1,f)
-        path2 = os.path.join(dir2,f)
+    def copy_update(dir1,dir2):
+        f1 = os.listdir(dir1)
+        for f in f1:
+            path1 = os.path.join(dir1,f)
+            path2 = os.path.join(dir2,f)
 
-        if os.path.isdir(path1):
-            if not os.path.exists(path2):
-                os.makedirs(path2)
-            copy_update(path1,path2)
-        else:
-            if not os.path.exists(path2):
-                shutil.copy(path1,path2)
+            if os.path.isdir(path1):
+                if not os.path.exists(path2):
+                    os.makedirs(path2)
+                copy_update(path1,path2)
             else:
-                stat1 = os.stat(path1)
-                stat2 = os.stat(path2)
-                if (stat1.st_mtime > stat2.st_mtime):
+                if not os.path.exists(path2):
                     shutil.copy(path1,path2)
+                else:
+                    stat1 = os.stat(path1)
+                    stat2 = os.stat(path2)
+                    if (stat1.st_mtime > stat2.st_mtime):
+                        shutil.copy(path1,path2)
 
-def configure_cfitsio():
-    os.chdir(cfitsio_build_dir)
-    ret=os.system('sh ./configure')
-    if ret != 0:
-        raise ValueError("could not configure cfitsio %s" % cfitsio_version)
-    os.chdir(package_basedir)
+    def configure_cfitsio():
+        os.chdir(cfitsio_build_dir)
+        ret=os.system('sh ./configure')
+        if ret != 0:
+            raise ValueError("could not configure cfitsio %s" % cfitsio_version)
+        os.chdir(package_basedir)
 
-def compile_cfitsio():
-    os.chdir(cfitsio_build_dir)
-    ret=os.system('make')
-    if ret != 0:
-        raise ValueError("could not compile cfitsio %s" % cfitsio_version)
-    os.chdir(package_basedir)
-
-
-if not os.path.exists('build'):
-    ret=os.makedirs('build')
-
-if not os.path.exists(cfitsio_build_dir):
-    ret=os.makedirs(cfitsio_build_dir)
-
-copy_update(cfitsio_dir, cfitsio_build_dir)
-
-if not os.path.exists(makefile):
-    configure_cfitsio()
-
-compile_cfitsio()
-
-data_files=[]
+    def compile_cfitsio():
+        os.chdir(cfitsio_build_dir)
+        ret=os.system('make')
+        if ret != 0:
+            raise ValueError("could not compile cfitsio %s" % cfitsio_version)
+        os.chdir(package_basedir)
 
 
-# when using "extra_objects" in Extension, changes in the objects do *not*
-# cause a re-link!  The only way I know is to force a recompile by removing the
-# directory
-build_libdir=glob.glob(os.path.join('build','lib*'))
-if len(build_libdir) > 0:
-    shutil.rmtree(build_libdir[0])
+    if not os.path.exists('build'):
+        ret=os.makedirs('build')
+
+    if not os.path.exists(cfitsio_build_dir):
+        ret=os.makedirs(cfitsio_build_dir)
+
+    copy_update(cfitsio_dir, cfitsio_build_dir)
+
+    if not os.path.exists(makefile):
+        configure_cfitsio()
+
+    compile_cfitsio()
+
+    # when using "extra_objects" in Extension, changes in the objects do *not*
+    # cause a re-link!  The only way I know is to force a recompile by removing the
+    # directory
+    build_libdir=glob.glob(os.path.join('build','lib*'))
+    if len(build_libdir) > 0:
+        shutil.rmtree(build_libdir[0])
+
+    extra_objects = glob.glob(os.path.join(cfitsio_build_dir,'*.o'))
+    extra_objects += glob.glob(os.path.join(cfitsio_zlib_dir,'*.o'))
+
+    include_dirs=[cfitsio_dir,numpy.get_include()]
+
+    if platform.system()=='Darwin':
+        extra_compile_args=['-arch','x86_64']
+        extra_link_args=['-arch','x86_64']
+    else:
+        extra_compile_args=[]
+        extra_link_args=[]
+else:
+    extra_objects = None
+    include_dirs=[numpy.get_include()]
+    if platform.system()=='Darwin':
+        extra_compile_args=['-arch','x86_64']
+        extra_link_args=['-arch','x86_64','-lcfitsio']
+    else:
+        extra_compile_args=[]
+        extra_link_args=['-lcfitsio']
 
 sources = ["fitsio/fitsio_pywrap.c"]
+data_files=[]
 
-extra_objects = glob.glob(os.path.join(cfitsio_build_dir,'*.o'))
-extra_objects += glob.glob(os.path.join(cfitsio_zlib_dir,'*.o'))
-
-if platform.system()=='Darwin':
-    extra_compile_args=['-arch','x86_64']
-    extra_link_args=['-arch','x86_64']
-else:
-    extra_compile_args=[]
-    extra_link_args=[]
 ext=Extension("fitsio._fitsio_wrap", 
               sources,
               extra_objects=extra_objects,
               extra_compile_args=extra_compile_args, 
               extra_link_args=extra_link_args)
-
 
 description = ("A full featured python library to read from and "
                "write to FITS files.")
@@ -107,8 +124,6 @@ try:
 except ImportError:
     from distutils.command.build_py import build_py
 
-
-include_dirs=[cfitsio_dir,numpy.get_include()]
 setup(name="fitsio", 
       version="0.9.7",
       description=description,

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,15 @@ else:
     compile_fitsio_package = False
     sys.argv.remove("--use-system-fitsio")
 
+extra_objects = None
+include_dirs=[numpy.get_include()]
+if platform.system()=='Darwin':
+    extra_compile_args=['-arch','x86_64']
+    extra_link_args=['-arch','x86_64']
+else:
+    extra_compile_args=[]
+    extra_link_args=[]
+    
 if compile_fitsio_package:
     package_basedir = os.path.abspath(os.curdir)
 
@@ -81,23 +90,10 @@ if compile_fitsio_package:
     extra_objects = glob.glob(os.path.join(cfitsio_build_dir,'*.o'))
     extra_objects += glob.glob(os.path.join(cfitsio_zlib_dir,'*.o'))
 
-    include_dirs=[cfitsio_dir,numpy.get_include()]
+    include_dirs.append(cfitsio_dir)
 
-    if platform.system()=='Darwin':
-        extra_compile_args=['-arch','x86_64']
-        extra_link_args=['-arch','x86_64']
-    else:
-        extra_compile_args=[]
-        extra_link_args=[]
-else:
-    extra_objects = None
-    include_dirs=[numpy.get_include()]
-    if platform.system()=='Darwin':
-        extra_compile_args=['-arch','x86_64']
-        extra_link_args=['-arch','x86_64','-lcfitsio']
-    else:
-        extra_compile_args=[]
-        extra_link_args=['-lcfitsio']
+if not compile_fitsio_package:
+    extra_link_args.append('-lcfitsio')
 
 sources = ["fitsio/fitsio_pywrap.c"]
 data_files=[]
@@ -106,7 +102,8 @@ ext=Extension("fitsio._fitsio_wrap",
               sources,
               extra_objects=extra_objects,
               extra_compile_args=extra_compile_args, 
-              extra_link_args=extra_link_args)
+              extra_link_args=extra_link_args,
+              include_dirs=include_dirs)
 
 description = ("A full featured python library to read from and "
                "write to FITS files.")
@@ -137,9 +134,7 @@ setup(name="fitsio",
       packages=['fitsio'],
       data_files=data_files,
       ext_modules=[ext],
-      cmdclass = {"build_py":build_py},
-      include_dirs=include_dirs)
-
+      cmdclass = {"build_py":build_py})
 
 
 


### PR DESCRIPTION
I have added an option to use the system cfitsio distribution instead of recompiling. This option is turned off by default, but is a nice build feature to have. You can pass the option `--use-system-fitsio` directly to the `setupy.py` script. You should also be able to invoke it with `pip` via 
```python
pip install fitsio --install-option="--use-system-fitsio"
```
I know this breaks the bundling rule, but it gives users more flexibility when compiling `cfitsio` locally fails using the default `make` invoked in `setup.py`. 