### PR TITLE
Scalario

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -2611,7 +2611,8 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
         void* data=PyArray_DATA(array);
         npy_intp nrows=0;
         npy_int64* rows=NULL;
-        npy_intp stride=PyArray_STRIDE(array,0);
+        npy_intp * strides=PyArray_STRIDES(array);
+        npy_intp stride = strides?strides[0]:0;
         if (rowsObj == Py_None) {
             nrows = hdu->numrows;
         } else {

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -806,7 +806,7 @@ class TestReadWrite(unittest.TestCase):
         try:
             with fitsio.FITS(fname,'r',clobber=True) as fits:
                 # this shall not segfault.
-                x = fits[2]['CLASS_PERSON']['CLASS'][:]
+                x = fits[2]['CLASS'][:]
         finally:
             if os.path.exists(fname):
                 #pass

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -797,12 +797,14 @@ class TestReadWrite(unittest.TestCase):
         Test a basic table write, data and a header, then reading back in to
         check the values
         """
-        import urllib2 
-        f = urllib2.urlopen('http://dr12.sdss3.org/sas/dr12/sdss/spectro/redux/26/spectra/0556/spec-0556-51991-0009.fits')
         fname=tempfile.mktemp(prefix='fitsio-TableWrite-',suffix='.fits')
-        with open(fname, 'w') as file:
-            file.write(f.read())
 
+        with fitsio.FITS(fname,'rw',clobber=True) as fits:
+            data = numpy.empty(1, dtype=[('CLASS', 'S6')])
+            data['CLASS'] = 'GALAXY'
+            fits.write_table(data)
+            fits.write_table(data)
+            fits.write_table(data)
         try:
             with fitsio.FITS(fname,'r',clobber=True) as fits:
                 # this shall not segfault.

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -792,40 +792,20 @@ class TestReadWrite(unittest.TestCase):
                 #pass
                 os.remove(fname)
 
-    def testTableWriteReadScalar(self):
+    def testTableReadScalar(self):
         """
         Test a basic table write, data and a header, then reading back in to
         check the values
         """
-
+        import urllib2 
+        f = urllib2.urlopen('http://dr12.sdss3.org/sas/dr12/sdss/spectro/redux/26/spectra/0556/spec-0556-51991-0009.fits')
         fname=tempfile.mktemp(prefix='fitsio-TableWrite-',suffix='.fits')
-        data = self.data[0]
+        with open(fname, 'w') as file:
+            file.write(f.read())
+
         try:
-            with fitsio.FITS(fname,'rw',clobber=True) as fits:
-
-                try:
-                    fits.write_table(self.data[:1], header=self.keys, extname='mytable')
-                    write_success=True
-                except:
-                    write_success=False
-
-                self.assertTrue(write_success,"testing write does not raise an error")
-                if not write_success:
-                    skipTest("cannot test result if write failed")
-
-                d = fits[1].read()
-                print(len(d))
-
-                h = fits[1].read_header()
-                self.compare_headerlist_header(self.keys, h)
-
-            # now test read_column
-            with fitsio.FITS(fname) as fits:
-
-                for f in data.dtype.names:
-                    d = fits[1].read_column(f)
-                    self.compare_array(data[f], d, "table 1 single field read '%s'" % f)
-
+            with fitsio.FITS(fname,'r',clobber=True) as fits:
+                x = fits[2]['CLASS_PERSON']['CLASS'][:]
         finally:
             if os.path.exists(fname):
                 #pass

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -805,6 +805,7 @@ class TestReadWrite(unittest.TestCase):
 
         try:
             with fitsio.FITS(fname,'r',clobber=True) as fits:
+                # this shall not segfault.
                 x = fits[2]['CLASS_PERSON']['CLASS'][:]
         finally:
             if os.path.exists(fname):

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -792,6 +792,45 @@ class TestReadWrite(unittest.TestCase):
                 #pass
                 os.remove(fname)
 
+    def testTableWriteReadScalar(self):
+        """
+        Test a basic table write, data and a header, then reading back in to
+        check the values
+        """
+
+        fname=tempfile.mktemp(prefix='fitsio-TableWrite-',suffix='.fits')
+        data = self.data[0]
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+
+                try:
+                    fits.write_table(self.data[:1], header=self.keys, extname='mytable')
+                    write_success=True
+                except:
+                    write_success=False
+
+                self.assertTrue(write_success,"testing write does not raise an error")
+                if not write_success:
+                    skipTest("cannot test result if write failed")
+
+                d = fits[1].read()
+                print(len(d))
+
+                h = fits[1].read_header()
+                self.compare_headerlist_header(self.keys, h)
+
+            # now test read_column
+            with fitsio.FITS(fname) as fits:
+
+                for f in data.dtype.names:
+                    d = fits[1].read_column(f)
+                    self.compare_array(data[f], d, "table 1 single field read '%s'" % f)
+
+        finally:
+            if os.path.exists(fname):
+                #pass
+                os.remove(fname)
+
 
     def testTableWriteDictOfArraysScratch(self):
         """


### PR DESCRIPTION
Refer to the test case I added. 

Reading in SDSS DR12 spectra file can reproduce the core dump on scalar output arrays. 
The added test case does depend on urllib2, thus we need to find a way around this.
