### PR TITLE
added option to setup.py to use system cfitsio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,95 +1,109 @@
 import distutils
 from distutils.core import setup, Extension, Command
 import os
+import sys
 import numpy
 import glob
 import shutil
 import platform
 
-package_basedir = os.path.abspath(os.curdir)
+if "--use-system-fitsio" not in sys.argv:
+    compile_fitsio_package = True
+else:
+    compile_fitsio_package = False
+    sys.argv.remove("--use-system-fitsio")
 
-#cfitsio_version = '3280patch'
-cfitsio_version = '3370'
-cfitsio_dir = 'cfitsio%s' % cfitsio_version
-cfitsio_build_dir = os.path.join('build',cfitsio_dir)
-cfitsio_zlib_dir = os.path.join(cfitsio_build_dir,'zlib')
-
-makefile = os.path.join(cfitsio_build_dir, 'Makefile')
-
-def copy_update(dir1,dir2):
-    f1 = os.listdir(dir1)
-    for f in f1:
-        path1 = os.path.join(dir1,f)
-        path2 = os.path.join(dir2,f)
-
-        if os.path.isdir(path1):
-            if not os.path.exists(path2):
-                os.makedirs(path2)
-            copy_update(path1,path2)
-        else:
-            if not os.path.exists(path2):
-                shutil.copy(path1,path2)
-            else:
-                stat1 = os.stat(path1)
-                stat2 = os.stat(path2)
-                if (stat1.st_mtime > stat2.st_mtime):
-                    shutil.copy(path1,path2)
-
-def configure_cfitsio():
-    os.chdir(cfitsio_build_dir)
-    ret=os.system('sh ./configure')
-    if ret != 0:
-        raise ValueError("could not configure cfitsio %s" % cfitsio_version)
-    os.chdir(package_basedir)
-
-def compile_cfitsio():
-    os.chdir(cfitsio_build_dir)
-    ret=os.system('make')
-    if ret != 0:
-        raise ValueError("could not compile cfitsio %s" % cfitsio_version)
-    os.chdir(package_basedir)
-
-
-if not os.path.exists('build'):
-    ret=os.makedirs('build')
-
-if not os.path.exists(cfitsio_build_dir):
-    ret=os.makedirs(cfitsio_build_dir)
-
-copy_update(cfitsio_dir, cfitsio_build_dir)
-
-if not os.path.exists(makefile):
-    configure_cfitsio()
-
-compile_cfitsio()
-
-data_files=[]
-
-
-# when using "extra_objects" in Extension, changes in the objects do *not*
-# cause a re-link!  The only way I know is to force a recompile by removing the
-# directory
-build_libdir=glob.glob(os.path.join('build','lib*'))
-if len(build_libdir) > 0:
-    shutil.rmtree(build_libdir[0])
-
-sources = ["fitsio/fitsio_pywrap.c"]
-
-extra_objects = glob.glob(os.path.join(cfitsio_build_dir,'*.o'))
-extra_objects += glob.glob(os.path.join(cfitsio_zlib_dir,'*.o'))
-
+extra_objects = None
+include_dirs=[numpy.get_include()]
 if platform.system()=='Darwin':
     extra_compile_args=['-arch','x86_64']
     extra_link_args=['-arch','x86_64']
 else:
     extra_compile_args=[]
     extra_link_args=[]
+    
+if compile_fitsio_package:
+    package_basedir = os.path.abspath(os.curdir)
+
+    #cfitsio_version = '3280patch'
+    cfitsio_version = '3370'
+    cfitsio_dir = 'cfitsio%s' % cfitsio_version
+    cfitsio_build_dir = os.path.join('build',cfitsio_dir)
+    cfitsio_zlib_dir = os.path.join(cfitsio_build_dir,'zlib')
+    
+    makefile = os.path.join(cfitsio_build_dir, 'Makefile')
+
+    def copy_update(dir1,dir2):
+        f1 = os.listdir(dir1)
+        for f in f1:
+            path1 = os.path.join(dir1,f)
+            path2 = os.path.join(dir2,f)
+
+            if os.path.isdir(path1):
+                if not os.path.exists(path2):
+                    os.makedirs(path2)
+                copy_update(path1,path2)
+            else:
+                if not os.path.exists(path2):
+                    shutil.copy(path1,path2)
+                else:
+                    stat1 = os.stat(path1)
+                    stat2 = os.stat(path2)
+                    if (stat1.st_mtime > stat2.st_mtime):
+                        shutil.copy(path1,path2)
+
+    def configure_cfitsio():
+        os.chdir(cfitsio_build_dir)
+        ret=os.system('sh ./configure')
+        if ret != 0:
+            raise ValueError("could not configure cfitsio %s" % cfitsio_version)
+        os.chdir(package_basedir)
+
+    def compile_cfitsio():
+        os.chdir(cfitsio_build_dir)
+        ret=os.system('make')
+        if ret != 0:
+            raise ValueError("could not compile cfitsio %s" % cfitsio_version)
+        os.chdir(package_basedir)
+
+
+    if not os.path.exists('build'):
+        ret=os.makedirs('build')
+
+    if not os.path.exists(cfitsio_build_dir):
+        ret=os.makedirs(cfitsio_build_dir)
+
+    copy_update(cfitsio_dir, cfitsio_build_dir)
+
+    if not os.path.exists(makefile):
+        configure_cfitsio()
+
+    compile_cfitsio()
+
+    # when using "extra_objects" in Extension, changes in the objects do *not*
+    # cause a re-link!  The only way I know is to force a recompile by removing the
+    # directory
+    build_libdir=glob.glob(os.path.join('build','lib*'))
+    if len(build_libdir) > 0:
+        shutil.rmtree(build_libdir[0])
+
+    extra_objects = glob.glob(os.path.join(cfitsio_build_dir,'*.o'))
+    extra_objects += glob.glob(os.path.join(cfitsio_zlib_dir,'*.o'))
+
+    include_dirs.append(cfitsio_dir)
+
+if not compile_fitsio_package:
+    extra_link_args.append('-lcfitsio')
+
+sources = ["fitsio/fitsio_pywrap.c"]
+data_files=[]
+
 ext=Extension("fitsio._fitsio_wrap", 
               sources,
               extra_objects=extra_objects,
               extra_compile_args=extra_compile_args, 
-              extra_link_args=extra_link_args)
-
+              extra_link_args=extra_link_args,
+              include_dirs=include_dirs)
 
 description = ("A full featured python library to read from and "
                "write to FITS files.")
@@ -107,8 +121,6 @@ try:
 except ImportError:
     from distutils.command.build_py import build_py
 
-
-include_dirs=[cfitsio_dir,numpy.get_include()]
 setup(name="fitsio", 
       version="0.9.7",
       description=description,
@@ -122,9 +134,7 @@ setup(name="fitsio",
       packages=['fitsio'],
       data_files=data_files,
       ext_modules=[ext],
-      cmdclass = {"build_py":build_py},
-      include_dirs=include_dirs)
-
+      cmdclass = {"build_py":build_py})
 
 
 


### PR DESCRIPTION
This is a reimplementation of my previous pull request esheldon/fitsio#27. It adds the ability to build fitsio against the system cfitsio install. I tested the changes on my mac with python 2.7.10 and it worked fine. This pull request conflicts with esheldon/fitsio#52 (moving `include_dirs` to the extenstion build). I have implemented this change too.