### PR TITLE
Make fitsio not build the packaged cfitsio when you just want to run "clean"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,30 @@
 import distutils
 from distutils.core import setup, Extension, Command
+from distutils.command.build_ext import build_ext
+from distutils.command.clean import clean
+from distutils.dir_util import remove_tree
 import os
 import sys
 import numpy
 import glob
 import shutil
 import platform
+try:
+    from distutils.command.build_py import build_py_2to3 as build_py
+except ImportError:
+    from distutils.command.build_py import build_py
+
+#Packaged version
+cfitsio_version = '3370'
+cfitsio_dir = 'cfitsio%s' % cfitsio_version
+cfitsio_build_dir = os.path.join('build',cfitsio_dir)
+cfitsio_zlib_dir = os.path.join(cfitsio_build_dir,'zlib')
+package_basedir = os.path.abspath(os.curdir)
 
 if "--use-system-fitsio" not in sys.argv:
     compile_fitsio_package = True
 else:
+    print "Using SYSTEM CFITSIO"
     compile_fitsio_package = False
     sys.argv.remove("--use-system-fitsio")
 
@@ -22,18 +37,61 @@ else:
     extra_compile_args=[]
     extra_link_args=[]
     
-if compile_fitsio_package:
-    package_basedir = os.path.abspath(os.curdir)
 
-    #cfitsio_version = '3280patch'
-    cfitsio_version = '3370'
-    cfitsio_dir = 'cfitsio%s' % cfitsio_version
-    cfitsio_build_dir = os.path.join('build',cfitsio_dir)
-    cfitsio_zlib_dir = os.path.join(cfitsio_build_dir,'zlib')
-    
-    makefile = os.path.join(cfitsio_build_dir, 'Makefile')
+# when using "extra_objects" in Extension, changes in the objects do *not*
+# cause a re-link!  The only way I know is to force a recompile by removing the
+# directory
+build_libdir=glob.glob(os.path.join('build','lib*'))
+if len(build_libdir) > 0:
+    shutil.rmtree(build_libdir[0])
 
-    def copy_update(dir1,dir2):
+class CleanCfitsio(clean):
+    def run(self):
+        if os.path.exists(cfitsio_build_dir):
+            remove_tree(cfitsio_build_dir)
+        return clean.run(self)
+
+class BuildExtCfitsio(build_ext):
+    def run(self):
+        print "Custom builder"
+        self.build_cfitsio()
+        return build_ext.run(self)
+
+    def build_cfitsio(self):
+
+        makefile = os.path.join(cfitsio_build_dir, 'Makefile')
+
+        if not os.path.exists('build'):
+            ret=os.makedirs('build')
+
+        if not os.path.exists(cfitsio_build_dir):
+            ret=os.makedirs(cfitsio_build_dir)
+
+        self.copy_update_cfitsio(cfitsio_dir, cfitsio_build_dir)
+
+        if not os.path.exists(makefile):
+            self.configure_cfitsio()
+
+        self.compile_cfitsio()
+
+
+    def configure_cfitsio(self):
+        os.chdir(cfitsio_build_dir)
+        ret=os.system('sh ./configure')
+        if ret != 0:
+            raise ValueError("could not configure cfitsio %s" % cfitsio_version)
+        os.chdir(package_basedir)
+
+    def compile_cfitsio(self):
+        os.chdir(cfitsio_build_dir)
+        ret=os.system('make')
+        if ret != 0:
+            raise ValueError("could not compile cfitsio %s" % cfitsio_version)
+        os.chdir(package_basedir)
+
+
+    @classmethod
+    def copy_update_cfitsio(cls, dir1,dir2):
         f1 = os.listdir(dir1)
         for f in f1:
             path1 = os.path.join(dir1,f)
@@ -42,7 +100,7 @@ if compile_fitsio_package:
             if os.path.isdir(path1):
                 if not os.path.exists(path2):
                     os.makedirs(path2)
-                copy_update(path1,path2)
+                cls.copy_update_cfitsio(path1,path2)
             else:
                 if not os.path.exists(path2):
                     shutil.copy(path1,path2)
@@ -52,48 +110,17 @@ if compile_fitsio_package:
                     if (stat1.st_mtime > stat2.st_mtime):
                         shutil.copy(path1,path2)
 
-    def configure_cfitsio():
-        os.chdir(cfitsio_build_dir)
-        ret=os.system('sh ./configure')
-        if ret != 0:
-            raise ValueError("could not configure cfitsio %s" % cfitsio_version)
-        os.chdir(package_basedir)
-
-    def compile_cfitsio():
-        os.chdir(cfitsio_build_dir)
-        ret=os.system('make')
-        if ret != 0:
-            raise ValueError("could not compile cfitsio %s" % cfitsio_version)
-        os.chdir(package_basedir)
 
 
-    if not os.path.exists('build'):
-        ret=os.makedirs('build')
 
-    if not os.path.exists(cfitsio_build_dir):
-        ret=os.makedirs(cfitsio_build_dir)
-
-    copy_update(cfitsio_dir, cfitsio_build_dir)
-
-    if not os.path.exists(makefile):
-        configure_cfitsio()
-
-    compile_cfitsio()
-
-    # when using "extra_objects" in Extension, changes in the objects do *not*
-    # cause a re-link!  The only way I know is to force a recompile by removing the
-    # directory
-    build_libdir=glob.glob(os.path.join('build','lib*'))
-    if len(build_libdir) > 0:
-        shutil.rmtree(build_libdir[0])
-
+if compile_fitsio_package:
     extra_objects = glob.glob(os.path.join(cfitsio_build_dir,'*.o'))
     extra_objects += glob.glob(os.path.join(cfitsio_zlib_dir,'*.o'))
-
     include_dirs.append(cfitsio_dir)
-
-if not compile_fitsio_package:
+    builder_class = BuildExtCfitsio
+else:
     extra_link_args.append('-lcfitsio')
+    builder_class = build_ext
 
 sources = ["fitsio/fitsio_pywrap.c"]
 data_files=[]
@@ -116,10 +143,6 @@ classifiers = ["Development Status :: 5 - Production/Stable"
                ,"Intended Audience :: Science/Research"
               ]
 
-try:
-    from distutils.command.build_py import build_py_2to3 as build_py
-except ImportError:
-    from distutils.command.build_py import build_py
 
 setup(name="fitsio", 
       version="0.9.7",
@@ -134,7 +157,7 @@ setup(name="fitsio",
       packages=['fitsio'],
       data_files=data_files,
       ext_modules=[ext],
-      cmdclass = {"build_py":build_py})
+      cmdclass = {"build_py":build_py, "build_ext":builder_class, "clean":CleanCfitsio})
 
 
 


### PR DESCRIPTION
This change hooks the cfitsio building code in the setup.py into the standard distutils build system by sub-classing the distutils commands build and clean commands.  It makes building cfitsio part of building the extension itself.

This means that the clean command now works properly.

I haven't tried this with python 3.

Cheers!
Joe
