### PR TITLE
Add travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ install:
     - source activate test
     - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py
     - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
-    - python setup.py install |tee build.log | tail
+    - python setup.py install
 
 script:
-    - echo OK # run the tests, later
+    - python setup.py build
+    - python setup.py build_ext
 
 #notifications:
 #  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+python:
+    - 2.6
+    - 2.7
+    - 3.3
+    - 3.4
+
+env:
+    - NUMPY_VERSION=1.8 
+    - NUMPY_VERSION=1.9
+
+#cache:
+#    directories:
+#        - $HOME/build/rainwoodman/pfft-python/build/depends
+
+before_install:
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b
+    - export PATH=/home/travis/miniconda/bin:$PATH
+    - conda update --yes conda
+
+install:
+    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
+    - source activate test
+    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py
+    - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
+    - python setup.py install |tee build.log | tail
+
+script:
+    - echo OK # run the tests, later
+
+#notifications:
+#  email: false


### PR DESCRIPTION
This travis-ci only tests the build and install of the package.

Enable this by flipping the switch on esheldon/fitsio after logging in at travis-ci.org. 

https://api.travis-ci.org/esheldon/fistio.svg shall contain the build status badge.

Note that the test cases in test.py are not enabled in travis. 
As there are currently 1 failure with 2 errors.

