### PR TITLE
customize includedir and libdir of system cfitsio.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ install:
     - source activate test
     - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py
     - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
-    - python setup.py install |tee build.log | tail
+    - python setup.py install
 
 script:
-    - echo OK # run the tests, later
+    - python setup.py build
+    - python setup.py build_ext
 
 #notifications:
 #  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+python:
+    - 2.6
+    - 2.7
+    - 3.3
+    - 3.4
+
+env:
+    - NUMPY_VERSION=1.8 
+    - NUMPY_VERSION=1.9
+
+#cache:
+#    directories:
+#        - $HOME/build/rainwoodman/pfft-python/build/depends
+
+before_install:
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b
+    - export PATH=/home/travis/miniconda/bin:$PATH
+    - conda update --yes conda
+
+install:
+    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
+    - source activate test
+    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py
+    - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
+    - python setup.py install |tee build.log | tail
+
+script:
+    - echo OK # run the tests, later
+
+#notifications:
+#  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,23 @@ before_install:
     - ./miniconda.sh -b
     - export PATH=/home/travis/miniconda/bin:$PATH
     - conda update --yes conda
+    - wget ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3370.tar.gz
+    - tar -xzvf cfitsio3370.tar.gz
+    - (cd cfitsio; ./configure --disable-shared --prefix=$HOME/cfitsio-static-install; make install -j 4)
 
 install:
     - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
     - source activate test
-    - conda install --yes numpy=$NUMPY_VERSION nose cython mpi4py
+    - conda install --yes numpy=$NUMPY_VERSION nose cython
     - if [ $TRAVIS_PYTHON_VERSION == 2.6 ]; then conda install --yes argparse; fi
-    - python setup.py install
 
 script:
-    - python setup.py build
+    - python setup.py install --prefix=$HOME/fitsio-install-bundle
+    - python setup.py clean -a 
+    - python setup.py install --prefix=$HOME/fitsio-install-static build_ext --use-system-fitsio --system-fitsio-includedir=$HOME/cfitsio-static-install/include --system-fitsio-libdir=$HOME/cfitsio-static-install/lib
+    - python setup.py clean -a
+    - python setup.py build 
+    - python setup.py clean -a
     - python setup.py build_ext
 
 #notifications:

--- a/setup.py
+++ b/setup.py
@@ -15,33 +15,27 @@ class build_ext_subclass(build_ext):
     user_options = build_ext.user_options + \
             [('use-system-fitsio', None, 
               "Use the cfitsio installed in the system")]
+    #cfitsio_version = '3280patch'
+    cfitsio_version = '3370patch'
+    cfitsio_dir = 'cfitsio%s' % cfitsio_version
 
     def initialize_options(self):
         self.use_system_fitsio = False
-
-
         build_ext.initialize_options(self)    
-        self.link_objects = []
-        self.extra_link_args = []
 
     def finalize_options(self):
 
         build_ext.finalize_options(self)    
 
-        #cfitsio_version = '3280patch'
-        self.cfitsio_version = '3370patch'
-        self.cfitsio_dir = 'cfitsio%s' % self.cfitsio_version
         self.cfitsio_build_dir = os.path.join(self.build_temp, self.cfitsio_dir)
         self.cfitsio_zlib_dir = os.path.join(self.cfitsio_build_dir,'zlib')
 
         if self.use_system_fitsio:
-            # Include bz2 by default?  Depends on how system cfitsio was built.
-            # FIXME: use pkg-config to tell if bz2 shall be included ?
-            self.extra_link_args.append('-lcfitsio')
+            pass
         else:
             # We defer configuration of the bundled cfitsio to build_extensions
             # because we will know the compiler there.
-            self.include_dirs.append(self.cfitsio_dir)
+            self.include_dirs.append(self.cfitsio_build_dir)
 
 
     def build_extensions(self):
@@ -73,6 +67,11 @@ class build_ext_subclass(build_ext):
             # so they will be properly rebuild if cfitsio source is updated.
             for ext in self.extensions:
                 ext.depends += link_objects
+        else:
+            # Include bz2 by default?  Depends on how system cfitsio was built.
+            # FIXME: use pkg-config to tell if bz2 shall be included ?
+            self.compiler.add_library('cfitsio')
+            pass
 
         # call the original build_extensions
 

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,25 @@ import platform
 
 class build_ext_subclass(build_ext):
     boolean_options = build_ext.boolean_options + ['use-system-fitsio']
+    
     user_options = build_ext.user_options + \
             [('use-system-fitsio', None, 
-              "Use the cfitsio installed in the system")]
+              "Use the cfitsio installed in the system"),
+
+             ('system-fitsio-includedir=', None,
+              "Path to look for cfitsio header; default is the system search path."),
+
+             ('system-fitsio-libdir=', None,
+              "Path to look for cfitsio library; default is the system search path."),
+            ]
     #cfitsio_version = '3280patch'
     cfitsio_version = '3370patch'
     cfitsio_dir = 'cfitsio%s' % cfitsio_version
 
     def initialize_options(self):
         self.use_system_fitsio = False
+        self.system_fitsio_includedir = None
+        self.system_fitsio_libdir = None
         build_ext.initialize_options(self)    
 
     def finalize_options(self):
@@ -31,11 +41,14 @@ class build_ext_subclass(build_ext):
         self.cfitsio_zlib_dir = os.path.join(self.cfitsio_build_dir,'zlib')
 
         if self.use_system_fitsio:
-            pass
+            if self.system_fitsio_includedir:
+                self.include_dirs.insert(0, self.system_fitsio_includedir)
+            if self.system_fitsio_libdir:
+                self.library_dirs.insert(0, self.system_fitsio_libdir)
         else:
             # We defer configuration of the bundled cfitsio to build_extensions
             # because we will know the compiler there.
-            self.include_dirs.append(self.cfitsio_build_dir)
+            self.include_dirs.insert(0, self.cfitsio_build_dir)
 
 
     def build_extensions(self):


### PR DESCRIPTION
Note that the proper way of setting up these 'build_ext' options is via explicitly adding build_ext subcommand on the commandline, e.g.

```
python setup.py install build_ext --use-system-fitsio
``