### PR TITLE
Add ability to shrink tables

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -2210,6 +2210,41 @@ PyFITSObject_write_var_column(struct PyFITSObject* self, PyObject* args, PyObjec
     Py_RETURN_NONE;
 }
 
+// function to delete rows from a table
+static PyObject *
+PyFITSObject_delete_rows(struct PyFITSObject* self, PyObject* args, PyObject* kwds) {
+    int status = 0;
+    int hdunum = 0;
+    int hdutype = 0;
+    Py_ssize_t start = 0, number = 0, end = 0;
+
+    static char *kwlist[] = {
+        "hdunum", "start", "end", NULL,
+    };
+
+    if (self->fits == NULL) {
+        PyErr_SetString(PyExc_ValueError, "fits file is NULL");
+        return NULL;
+    }
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "inn", kwlist,
+                &hdunum, &start, &end)) {
+        return NULL;
+    }
+
+    if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
+        set_ioerr_string_from_status(status);
+        return NULL;
+    }
+
+    number = end - start;
+    if (fits_delete_rows(self->fits, start + 1, number, &status)) {
+        set_ioerr_string_from_status(status);
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
 
  
 
@@ -3957,6 +3992,8 @@ static PyMethodDef PyFITSObject_methods[] = {
     {"write_column",         (PyCFunction)PyFITSObject_write_column,         METH_VARARGS | METH_KEYWORDS, "write_column\n\nWrite a column into the specifed hdu."},
     {"write_columns",        (PyCFunction)PyFITSObject_write_columns,        METH_VARARGS | METH_KEYWORDS, "write_columns\n\nWrite columns into the specifed hdu."},
     {"write_var_column",     (PyCFunction)PyFITSObject_write_var_column,     METH_VARARGS | METH_KEYWORDS, "write_var_column\n\nWrite a variable length column into the specifed hdu from an object array."},
+    {"delete_rows",    (PyCFunction)PyFITSObject_delete_rows,    METH_VARARGS | METH_KEYWORDS,
+        "delete_rows\nDelete rows from a table extension"},
     {"write_string_key",     (PyCFunction)PyFITSObject_write_string_key,     METH_VARARGS,  "write_string_key\n\nWrite a string key into the specified HDU."},
     {"write_double_key",     (PyCFunction)PyFITSObject_write_double_key,     METH_VARARGS,  "write_double_key\n\nWrite a double key into the specified HDU."},
 

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -2231,7 +2231,7 @@ PyFITSObject_delete_rows(struct PyFITSObject* self, PyObject* args, PyObject* kw
         return NULL;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "inn", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "in|n", kwlist,
                 &hdunum, &start, &end)) {
         return NULL;
     }
@@ -2242,7 +2242,12 @@ PyFITSObject_delete_rows(struct PyFITSObject* self, PyObject* args, PyObject* kw
         return NULL;
     }
     start = MAX(start, 1);
-    end = MIN(end, num_rows);
+
+    if (end == 0) {
+        end = num_rows;
+    } else {
+        end = MIN(end, num_rows);
+    }
 
     if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
         set_ioerr_string_from_status(status);

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -2441,6 +2441,18 @@ class TableHDU(HDUBase):
         if self.trim_strings or trim_strings:
             _trim_strings(array)
 
+    def _shrink_to(self, target_nrows):
+        """
+        Delete the last rows of the table, leaving 'nrows' remaining
+        """
+        current_nrows = self._info['nrows']
+        if current_nrows > target_nrows:
+            start = target_nrows
+            self._FITS.delete_rows(self._ext+1, start=start)
+        else:
+            raise ValueError("Target number of rows greater than the table "
+                             "contains")
+
     def _convert_bool_array(self, array):
         """
         cfitsio reads as characters 'T' and 'F' -- convert to real boolean

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1535,6 +1535,9 @@ class TableHDU(HDUBase):
             You can also send names=
         names: list, optional
             same as columns=
+        resize: boolean, optional
+            If less data is being written to the table than already exists,
+            then automatically resize the number of rows to match the new data.
         """
 
         slow = keys.get('slow',False)
@@ -1607,6 +1610,10 @@ class TableHDU(HDUBase):
                 self._FITS.write_columns(self._ext+1, nonobj_colnums, nonobj_arrays, 
                                          firstrow=firstrow+1)
 
+
+        # Assume all of the columns are the same length
+        nrows = len(data_list[0])
+
         # writing the object arrays always occurs the same way
         # need to make sure this works for array fields
         for i,name in enumerate(names):
@@ -1614,6 +1621,9 @@ class TableHDU(HDUBase):
                 self.write_var_column(name, data_list[i], **keys)
 
         self._update_info()
+
+        if keys.get('resize'):
+            self._shrink_to(nrows)
 
     def write_column(self, column, data, **keys):
         """

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1782,6 +1782,16 @@ class TestTableEditing(unittest.TestCase):
         self.f.close()
         self.assertDataMatches(array([0, 1, 2, 3, 4]))
 
+    # High level interface
+    def test_resize_table(self):
+        test_data = array([1, 2])
+        self.hdu.write({
+            self.column_name: test_data
+        })
+        self.hdu._shrink_to(test_data.size)
+        self.f.close()
+
+        self.assertDataMatches(array([1, 2]))
 
 
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1793,7 +1793,14 @@ class TestTableEditing(unittest.TestCase):
 
         self.assertDataMatches(array([1, 2]))
 
+    def test_resize_with_write_keyword(self):
+        test_data = array([1, 2])
+        self.hdu.write({
+            self.column_name: test_data
+        }, resize=True)
+        self.f.close()
 
+        self.assertDataMatches(array([1, 2]))
 
 if __name__ == '__main__':
     test()

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1776,6 +1776,14 @@ class TestTableEditing(unittest.TestCase):
         self.f.close()
         self.assertDataMatches(array([0, 1]))
 
+    def test_passing_none_to_end_deletes_the_end(self):
+        self.hdu._FITS.delete_rows(self.hdu._ext+1, start=5)
+        # Have to close the file to flush to disc
+        self.f.close()
+        self.assertDataMatches(array([0, 1, 2, 3, 4]))
+
+
+
 
 if __name__ == '__main__':
     test()

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -25,11 +25,12 @@ def test():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestReadWrite)
     res2=unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
 
-    if not res1 or not res2:
+    suite_extra = unittest.TestLoader().loadTestsFromTestCase(TestTableEditing)
+    res3=unittest.TextTestRunner(verbosity=2).run(suite_extra)
+
+    if not res1 or not res2 or not res3:
         sys.exit(1)
 
-    suite_extra = unittest.TestLoader().loadTestsFromTestCase(TestTableEditing)
-    unittest.TextTestRunner(verbosity=2).run(suite_extra)
 
 class TestWarnings(unittest.TestCase):
     """

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -50,7 +50,7 @@ class TestWarnings(unittest.TestCase):
                 # now write a key with a non-standard value
                 value={'test':3}
                 fits[-1].write_key("odd",value)
-            
+
             assert len(w) == 1
             assert issubclass(w[-1].category, fitsio.FITSRuntimeWarning)
 
@@ -85,7 +85,7 @@ class TestReadWrite(unittest.TestCase):
                ('f8vec','f8',nvec),
                ('c8vec','c8',nvec),
                ('c16vec','c16',nvec),
- 
+
                ('u1arr','u1',ashape),
                ('i1arr','i1',ashape),
                ('b1arr','?',ashape),
@@ -141,7 +141,7 @@ class TestReadWrite(unittest.TestCase):
 
         # strings get padded when written to the fits file.  And the way I do
         # the read, I read all bytes (ala mrdfits) so the spaces are preserved.
-        # 
+        #
         # so we need to pad out the strings with blanks so we can compare
 
         data['Sscalar'] = ['%-6s' % s for s in ['hello','world','good','bye']]
@@ -240,7 +240,7 @@ class TestReadWrite(unittest.TestCase):
                ('i8vec','i8',nvec),
                ('f4vec','f4',nvec),
                ('f8vec','f8',nvec),
- 
+
                ('u1arr','u1',ashape),
                ('i1arr','i1',ashape),
                ('u2arr','u2',ashape),
@@ -275,7 +275,7 @@ class TestReadWrite(unittest.TestCase):
 
         # strings get padded when written to the fits file.  And the way I do
         # the read, I real all bytes (ala mrdfits) so the spaces are preserved.
-        # 
+        #
         # so for comparisons, we need to pad out the strings with blanks so we
         # can compare
 
@@ -329,7 +329,7 @@ class TestReadWrite(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.remove(fname)
- 
+
 
     def testImageWriteReadFromDims(self):
         """
@@ -360,7 +360,7 @@ class TestReadWrite(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.remove(fname)
- 
+
     def testImageWriteReadFromDimsChunks(self):
         """
         Test a basic image write, data and a header, then reading back in to
@@ -395,7 +395,7 @@ class TestReadWrite(unittest.TestCase):
                     self.compare_array(data, rdata, "images")
 
 
-                    # 
+                    #
                     # now using sequence, easier to calculate
                     #
 
@@ -420,7 +420,7 @@ class TestReadWrite(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.remove(fname)
- 
+
 
     def testImageSlice(self):
         fname=tempfile.mktemp(prefix='fitsio-ImageSlice-',suffix='.fits')
@@ -516,7 +516,7 @@ class TestReadWrite(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.remove(fname)
- 
+
     def testGZIPTileCompressedWriteRead(self):
         """
         Test a basic image write, data and a header, then reading back in to
@@ -540,7 +540,7 @@ class TestReadWrite(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.remove(fname)
- 
+
     def testHCompressTileCompressedWriteRead(self):
         """
         Test a basic image write, data and a header, then reading back in to
@@ -565,7 +565,7 @@ class TestReadWrite(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.remove(fname)
- 
+
 
 
 
@@ -692,7 +692,7 @@ class TestReadWrite(unittest.TestCase):
                     for f in self.vardata.dtype.names:
                         d = fits[1].read_column(f)
                         if fitsio.fitslib.is_object(self.vardata[f]):
-                            self.compare_object_array(self.vardata[f], d, 
+                            self.compare_object_array(self.vardata[f], d,
                                                       "read all field '%s'" % f)
 
                     # same as above with slices
@@ -707,10 +707,10 @@ class TestReadWrite(unittest.TestCase):
                     for f in self.vardata.dtype.names:
                         d = fits[1][f][:]
                         if fitsio.fitslib.is_object(self.vardata[f]):
-                            self.compare_object_array(self.vardata[f], d, 
+                            self.compare_object_array(self.vardata[f], d,
                                                       "read all field '%s'" % f)
 
- 
+
 
                     #
                     # now same with sub rows
@@ -719,47 +719,47 @@ class TestReadWrite(unittest.TestCase):
                     # reading multiple columns
                     rows = numpy.array([0,2])
                     d = fits[1].read(rows=rows)
-                    self.compare_rec_with_var(self.vardata,d,"read subrows test '%s'" % vstorage, 
+                    self.compare_rec_with_var(self.vardata,d,"read subrows test '%s'" % vstorage,
                                               rows=rows)
 
                     d = fits[1].read(columns=cols, rows=rows)
-                    self.compare_rec_with_var(self.vardata,d,"read subrows test subcols '%s'" % vstorage, 
+                    self.compare_rec_with_var(self.vardata,d,"read subrows test subcols '%s'" % vstorage,
                                               rows=rows)
 
                     # one at a time
                     for f in self.vardata.dtype.names:
                         d = fits[1].read_column(f,rows=rows)
                         if fitsio.fitslib.is_object(self.vardata[f]):
-                            self.compare_object_array(self.vardata[f], d, 
+                            self.compare_object_array(self.vardata[f], d,
                                                       "read subrows field '%s'" % f,
                                                       rows=rows)
 
                     # same as above with slices
                     # reading multiple columns
                     d = fits[1][rows]
-                    self.compare_rec_with_var(self.vardata,d,"read subrows slice test '%s'" % vstorage, 
+                    self.compare_rec_with_var(self.vardata,d,"read subrows slice test '%s'" % vstorage,
                                               rows=rows)
                     d = fits[1][2:4]
-                    self.compare_rec_with_var(self.vardata,d,"read slice test '%s'" % vstorage, 
+                    self.compare_rec_with_var(self.vardata,d,"read slice test '%s'" % vstorage,
                                               rows=numpy.array([2,3]))
 
                     d = fits[1][cols][rows]
-                    self.compare_rec_with_var(self.vardata,d,"read subcols subrows slice test '%s'" % vstorage, 
+                    self.compare_rec_with_var(self.vardata,d,"read subcols subrows slice test '%s'" % vstorage,
                                               rows=rows)
                     d = fits[1][cols][2:4]
-                    self.compare_rec_with_var(self.vardata,d,"read subcols slice test '%s'" % vstorage, 
+                    self.compare_rec_with_var(self.vardata,d,"read subcols slice test '%s'" % vstorage,
                                               rows=numpy.array([2,3]))
 
                     # one at a time
                     for f in self.vardata.dtype.names:
                         d = fits[1][f][rows]
                         if fitsio.fitslib.is_object(self.vardata[f]):
-                            self.compare_object_array(self.vardata[f], d, 
+                            self.compare_object_array(self.vardata[f], d,
                                                       "read subrows field '%s'" % f,
                                                       rows=rows)
                         d = fits[1][f][2:4]
                         if fitsio.fitslib.is_object(self.vardata[f]):
-                            self.compare_object_array(self.vardata[f], d, 
+                            self.compare_object_array(self.vardata[f], d,
                                                       "read slice field '%s'" % f,
                                                       rows=numpy.array([2,3]))
 
@@ -799,8 +799,8 @@ class TestReadWrite(unittest.TestCase):
                 self.compare_headerlist_header(self.keys, h)
 
             # see if our convenience functions are working
-            fitsio.write(fname, self.data2, 
-                         extname="newext", 
+            fitsio.write(fname, self.data2,
+                         extname="newext",
                          header={'ra':335.2,'dec':-25.2})
             d = fitsio.read(fname, ext='newext')
             self.compare_rec(self.data2, d, "table data2")
@@ -819,13 +819,13 @@ class TestReadWrite(unittest.TestCase):
                 for cols in [['u2scalar','f4vec','Sarr'],
                              ['f8scalar','u2arr','Sscalar']]:
                     d = fits[1].read(columns=cols)
-                    for f in d.dtype.names: 
+                    for f in d.dtype.names:
                         self.compare_array(self.data[f][:], d[f], "test column list %s" % f)
 
 
                     rows = [1,3]
                     d = fits[1].read(columns=cols, rows=rows)
-                    for f in d.dtype.names: 
+                    for f in d.dtype.names:
                         self.compare_array(self.data[f][rows], d[f], "test column list %s row subset" % f)
 
         finally:
@@ -1077,7 +1077,7 @@ class TestReadWrite(unittest.TestCase):
             with fitsio.FITS(fname,'rw',clobber=True) as fits:
 
                 fits.write_table(self.ascii_data, table_type='ascii', header=self.keys, extname='mytable')
-                
+
                 # cfitsio always reports type as i4 and f8, period, even if if
                 # written with higher precision.  Need to fix that somehow
                 for f in self.ascii_data.dtype.names:
@@ -1093,10 +1093,10 @@ class TestReadWrite(unittest.TestCase):
                 for f in self.ascii_data.dtype.names:
                     d = fits[1].read_column(f,rows=rows)
                     if d.dtype == numpy.float64:
-                        self.compare_array_tol(self.ascii_data[f][rows], d, 2.15e-16, 
+                        self.compare_array_tol(self.ascii_data[f][rows], d, 2.15e-16,
                                                "table field read subrows '%s'" % f)
                     else:
-                        self.compare_array(self.ascii_data[f][rows], d, 
+                        self.compare_array(self.ascii_data[f][rows], d,
                                            "table field read subrows '%s'" % f)
 
                 beg=1
@@ -1104,10 +1104,10 @@ class TestReadWrite(unittest.TestCase):
                 for f in self.ascii_data.dtype.names:
                     d = fits[1][f][beg:end]
                     if d.dtype == numpy.float64:
-                        self.compare_array_tol(self.ascii_data[f][beg:end], d, 2.15e-16, 
+                        self.compare_array_tol(self.ascii_data[f][beg:end], d, 2.15e-16,
                                                "table field read slice '%s'" % f)
                     else:
-                        self.compare_array(self.ascii_data[f][beg:end], d, 
+                        self.compare_array(self.ascii_data[f][beg:end], d,
                                            "table field read slice '%s'" % f)
 
                 cols = ['i2scalar','f4scalar']
@@ -1134,20 +1134,20 @@ class TestReadWrite(unittest.TestCase):
                     for f in data.dtype.names:
                         d=data[f]
                         if d.dtype == numpy.float64:
-                            self.compare_array_tol(self.ascii_data[f][rows], d, 2.15e-16, 
+                            self.compare_array_tol(self.ascii_data[f][rows], d, 2.15e-16,
                                                    "table subcol, '%s'" % f)
                         else:
-                            self.compare_array(self.ascii_data[f][rows], d, 
+                            self.compare_array(self.ascii_data[f][rows], d,
                                                "table subcol, '%s'" % f)
 
                     data = fits[1][cols][rows]
                     for f in data.dtype.names:
                         d=data[f]
                         if d.dtype == numpy.float64:
-                            self.compare_array_tol(self.ascii_data[f][rows], d, 2.15e-16, 
+                            self.compare_array_tol(self.ascii_data[f][rows], d, 2.15e-16,
                                                    "table subcol/row, '%s'" % f)
                         else:
-                            self.compare_array(self.ascii_data[f][rows], d, 
+                            self.compare_array(self.ascii_data[f][rows], d,
                                                "table subcol/row, '%s'" % f)
 
                 for f in self.ascii_data.dtype.names:
@@ -1156,10 +1156,10 @@ class TestReadWrite(unittest.TestCase):
                     for f in data.dtype.names:
                         d=data[f]
                         if d.dtype == numpy.float64:
-                            self.compare_array_tol(self.ascii_data[f][beg:end], d, 2.15e-16, 
+                            self.compare_array_tol(self.ascii_data[f][beg:end], d, 2.15e-16,
                                                    "table subcol/slice, '%s'" % f)
                         else:
-                            self.compare_array(self.ascii_data[f][beg:end], d, 
+                            self.compare_array(self.ascii_data[f][beg:end], d,
                                                "table subcol/slice, '%s'" % f)
 
 
@@ -1226,18 +1226,18 @@ class TestReadWrite(unittest.TestCase):
                 # now list of columns
                 cols=['u2scalar','f4vec','Sarr']
                 d = fits[1][cols][:]
-                for f in d.dtype.names: 
+                for f in d.dtype.names:
                     self.compare_array(self.data[f][:], d[f], "test column list %s" % f)
 
 
                 cols=['u2scalar','f4vec','Sarr']
                 d = fits[1][cols][rows]
-                for f in d.dtype.names: 
+                for f in d.dtype.names:
                     self.compare_array(self.data[f][rows], d[f], "test column list %s row subset" % f)
 
                 cols=['u2scalar','f4vec','Sarr']
                 d = fits[1][cols][1:3]
-                for f in d.dtype.names: 
+                for f in d.dtype.names:
                     self.compare_array(self.data[f][1:3], d[f], "test column list %s row slice" % f)
 
 
@@ -1370,12 +1370,12 @@ class TestReadWrite(unittest.TestCase):
             fits = fitsio.FITS(fname,'rw',clobber=True)
             fits.write_table(self.data, header=self.keys, extname='mytable')
             fits.close()
-    
+
             os.system('bzip2 %s' % fname)
             f2 = fitsio.FITS(bzfname)
             d = f2[1].read()
             self.compare_rec(self.data, d, "bzip2 read")
-    
+
             h = f2[1].read_header()
             for entry in self.keys:
                 name=entry['name'].upper()
@@ -1638,7 +1638,7 @@ class TestReadWrite(unittest.TestCase):
                              "testing array '%s' dim %d are "
                              "equal within tolerance %e, found "
                              "max diff %e" % (name,i,tol,maxdiff))
-        
+
     def compare_array(self, arr1, arr2, name):
         self.assertEqual(arr1.shape, arr2.shape,
                          "testing arrays '%s' shapes are equal: "
@@ -1691,14 +1691,14 @@ class TestReadWrite(unittest.TestCase):
 
             # f1 will have the objects
             if fitsio.fitslib.is_object(rec1[f]):
-                self.compare_object_array(rec1[f], rec2[f], 
+                self.compare_object_array(rec1[f], rec2[f],
                                           "testing '%s' field '%s'" % (name,f),
                                           rows=rows)
-            else:                    
-                self.compare_array(rec1[f][rows], rec2[f], 
+            else:
+                self.compare_array(rec1[f][rows], rec2[f],
                                    "testing '%s' num field '%s' equal" % (name,f))
 
-    def compare_object_array(self, arr1, arr2, name, rows=None): 
+    def compare_object_array(self, arr1, arr2, name, rows=None):
         """
         The first must be object
         """
@@ -1713,7 +1713,7 @@ class TestReadWrite(unittest.TestCase):
                 delement = arr2[i]
                 orig = arr1[row]
                 s=len(orig)
-                self.compare_array(orig, delement[0:s], 
+                self.compare_array(orig, delement[0:s],
                                    "%s num el %d equal" % (name,i))
 
     def compare_rec_with_var_subrows(self, rec1, rec2, name, rows):
@@ -1733,10 +1733,10 @@ class TestReadWrite(unittest.TestCase):
                         delement = rec1[f][i]
                         orig = rec2[f][i]
                         s=orig.size
-                        self.compare_array(orig, delement[0:s], 
+                        self.compare_array(orig, delement[0:s],
                                            "testing '%s' num field '%s' el %d equal" % (name,f,i))
-            else:                    
-                self.compare_array(rec1[f], rec2[f], 
+            else:
+                self.compare_array(rec1[f], rec2[f],
                                    "testing '%s' num field '%s' equal" % (name,f))
 
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1769,13 +1769,12 @@ class TestTableEditing(unittest.TestCase):
         self.f.close()
         self.assertDataMatches(array([0, 1, 5, 6, 7, 8, 9]))
 
-        with fitsio.FITS(self.fname) as infile:
-            data = infile[self.hdu_name][self.column_name].read()
+    def test_supplying_endpoint_beyond_end(self):
+        self.hdu._FITS.delete_rows(self.hdu._ext+1, start=2, end=1000)
 
-        self.compare_array(data,
-                           array([0, 1, 5, 6, 7, 8, 9]),
-                           "testing data is equal")
-
+        # Have to close the file to flush to disc
+        self.f.close()
+        self.assertDataMatches(array([0, 1]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change allows the ability to shrink tables, either at the users request, or automatically when data is being overwritten.

Currently, as per cfitsio, when new rows are written to an existing table and the number of rows for the new data is less than the number of rows for the existing data, the new rows get overwritten but the old data still remains. This is quite dangerous if the user assumes the new data completely replaces the old data. This change adds functionality in three locations:
- At the C level, with `delete_rows` which deletes the rows between `start` and `end`. If `end` is not given, then delete all of the remaining rows,
- A new method on the `TableHDU` object, `_shrink_to` which deletes the last n rows leaving `target_nrows` remaining,
- A new keyword argument to `TableHDU.write`: `resize` which will automatically delete rows from the end of the table if the new data has fewer rows.

There are basic unit tests for each level, but they can certainly be tested and I haven't really thought of edge cases yet.
