### PR TITLE
Fix crash on 32-bit platforms

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1131,7 +1131,8 @@ static int set_compression(fitsfile *fits,
                            PyObject* tile_dims_obj,
                            int *status) {
 
-    npy_int64 *tile_dims_py=NULL, *tile_dims_fits=NULL;
+    npy_int64 *tile_dims_py=NULL;
+    long *tile_dims_fits=NULL;
     npy_intp ndims=0, i=0;
 
     // can be NOCOMPRESS (0)


### PR DESCRIPTION
`tile_dims_fits` is on the cfitsio side, so its type should be `long`. This fixes #83.