### PR TITLE
Fix more 32-bit sizeof issues

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1241,11 +1241,11 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
             // get dims from input, which must be of type 'i8'
             // this means we are not writing the array that was input,
             // it is only used to determine the data type
-            npy_intp *tptr=NULL, tmp=0;
+            npy_int64 *tptr=NULL, tmp=0;
             ndims = PyArray_SIZE(dims_obj);
             dims = calloc(ndims,sizeof(long));
             for (i=0; i<ndims; i++) {
-                tptr = (npy_intp *) PyArray_GETPTR1(dims_obj, i);
+                tptr = (npy_int64 *) PyArray_GETPTR1(dims_obj, i);
                 tmp = *tptr;
                 dims[ndims-i-1] = (long) tmp;
             }
@@ -3492,7 +3492,7 @@ static int get_long_slices(PyObject* fpix_arr,
                            long** step) {
 
     int i=0;
-    long* ptr=NULL;
+    npy_int64* ptr=NULL;
     npy_intp fsize=0, lsize=0, ssize=0;
 
     fsize=PyArray_SIZE(fpix_arr);


### PR DESCRIPTION
On MIPS and PowerPC, `sizeof(long) == 4`, so that one cannot replace `npy_int64` with `long` there. On MIPS, this leads to a [Floating point exception](https://buildd.debian.org/status/fetch.php?pkg=python-fitsio&arch=mips&ver=0.9.8%2Bdfsg-2&stamp=1460908617)
in `testImageSlice` (division by 0, since the stepsize is then errornously set to zero).

On PowerPC, this is catched, but [leads to a failure `testImageSlice`](https://buildd.debian.org/status/fetch.php?pkg=python-fitsio&arch=powerpc&ver=0.9.8%2Bdfsg-2&stamp=1460846389). On both platforms, `testImageWriteReadFromDimsChunks` and `testImageWriteReadFromDims` fail as well.

This patch uses `npy_int64` on the places where these problems appear.
With this patch, [PowerPC](https://buildd.debian.org/status/fetch.php?pkg=python-fitsio&arch=powerpc&ver=0.9.8%2Bdfsg-3&stamp=1461150157) and [MIPS](https://buildd.debian.org/status/fetch.php?pkg=python-fitsio&arch=mips&ver=0.9.8%2Bdfsg-3&stamp=1461152124) compile fine with all tests succeeding (except expected failures for bzip2 and compression, since the system cfitsio is used).