### PR TITLE
Allow aligned data

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -3426,6 +3426,8 @@ def array2tabledef(data, table_type='binary'):
             # the same type as the first
             name=d[0]
             form, dim = npy_obj2fits(data,name)
+        elif npy_dtype[0] == "V":
+            continue
         else:
             name, form, dim = npy2fits(d,table_type=table_type)
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -182,7 +182,8 @@ class TestReadWrite(unittest.TestCase):
                 ('f8scalar','f8'),
                 ('Sscalar',Sdtype)]
         nrows=4
-        adata=numpy.zeros(nrows, dtype=adtype)
+        # For armhf and sparc64, we need alignment here:
+        adata=numpy.zeros(nrows, dtype=numpy.dtype(adtype, align=True))
 
         adata['i2scalar'][:] = -32222  + numpy.arange(nrows,dtype='i2')
         adata['i4scalar'][:] = -1353423423 + numpy.arange(nrows,dtype='i4')

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -182,8 +182,11 @@ class TestReadWrite(unittest.TestCase):
                 ('f8scalar','f8'),
                 ('Sscalar',Sdtype)]
         nrows=4
-        # For armhf and sparc64, we need alignment here:
-        adata=numpy.zeros(nrows, dtype=numpy.dtype(adtype, align=True))
+        try:
+            tdt = numpy.dtype(adtype, align=True)
+        except TypeError: # older numpy may not understand `align` argument
+            tdt = numpy.dtype(adtype)
+        adata=numpy.zeros(nrows, dtype=tdt)
 
         adata['i2scalar'][:] = -32222  + numpy.arange(nrows,dtype='i2')
         adata['i4scalar'][:] = -1353423423 + numpy.arange(nrows,dtype='i4')


### PR DESCRIPTION
This pull request fixes partially #86, in the sense that one can now use tables that have a `dtype=numpy.dtype(..., align=True)` set. It also includes a fix for the ASCII table test to use aligned data. This is the only test that fails on the ARM platform (so, when applying this pull request, all tests for ARM [succeed](https://buildd.debian.org/status/fetch.php?pkg=python-fitsio&arch=armhf&ver=0.9.8%2Bdfsg-5&stamp=1461280405)); however for Sparc64 the other tests also result in a [segmentation fault] (https://buildd.debian.org/status/fetch.php?pkg=python-fitsio&arch=sparc64&ver=0.9.8%2Bdfsg-5&stamp=1461359715). I am not shure whether it is generally better to

- leave the decision to the user to use the `align` argument of `numpy.dtype` if he wants to use his software those platforms (which would make the software potentially unportable, with hard to find bugs later), or
- re-align the data in fitsio (this package), or
- handle this case in libcfitsio.
Any ideas?