### PR TITLE
Copy COMMENT and HEADER fields with write_keys

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1357,11 +1357,12 @@ class HDUBase(object):
         for r in hdr.records():
             name=r['name'].upper()
             value=r['value']
+            comment = r.get('comment','')
 
             if name=='COMMENT':
-                self.write_comment(value)
+                self.write_comment(comment)
             elif name=='HISTORY':
-                self.write_history(value)
+                self.write_history(comment)
             else:
                 comment=r.get('comment','')
                 self.write_key(name,value,comment=comment)


### PR DESCRIPTION
This might be a fix for issue #90, but I haven't tested it very throughly. It appears to work for the specific case that was bothering me (i.e., copying COMMENT strings), but I'm not sure about HISTORY.