### PR TITLE
read_raw

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -3525,7 +3525,7 @@ PyFITSObject_read_raw(struct PyFITSObject* self, PyObject* args) {
     // Allocate buffer for string
     sz = FITS->filesize;
     // Create python string object of requested size, unitialized
-    stringobj = PyString_FromStringAndSize(NULL, sz);
+    stringobj = PyBytes_FromStringAndSize(NULL, sz);
     if (!stringobj) {
         PyErr_Format(PyExc_RuntimeError,
                      "Failed to allocate python string object to hold FITS file data: %i bytes",
@@ -3533,8 +3533,9 @@ PyFITSObject_read_raw(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
     // Grab pointer to the memory buffer of the python string object
-    filedata = PyString_AsString(stringobj);
+    filedata = PyBytes_AsString(stringobj);
     if (!filedata) {
+        Py_DECREF(stringobj);
         return NULL;
     }
     // Remember old file position

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -3541,14 +3541,14 @@ PyFITSObject_read_raw(struct PyFITSObject* self, PyObject* args) {
     io_pos = FITS->io_pos;
     // Seek to beginning of file
     if (ffseek(FITS, 0)) {
-        free(filedata);
+        Py_DECREF(stringobj);
         PyErr_Format(PyExc_RuntimeError,
                      "Failed to seek to beginning of FITS file");
         return NULL;
     }
     // Read into filedata
     if (ffread(FITS, sz, filedata, &status)) {
-        free(filedata);
+        Py_DECREF(stringobj);
         PyErr_Format(PyExc_RuntimeError,
                      "Failed to read file data into memory: CFITSIO code %i",
                      status);
@@ -3556,7 +3556,7 @@ PyFITSObject_read_raw(struct PyFITSObject* self, PyObject* args) {
     }
     // Seek back to where we were
     if (ffseek(FITS, io_pos)) {
-        free(filedata);
+        Py_DECREF(stringobj);
         PyErr_Format(PyExc_RuntimeError,
                      "Failed to seek back to original FITS file position");
         return NULL;

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -3501,6 +3501,86 @@ PyFITSObject_read_image(struct PyFITSObject* self, PyObject* args) {
 }
 
 
+static PyObject *
+PyFITSObject_read_raw(struct PyFITSObject* self, PyObject* args) {
+    if (self->fits == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "FITS file is NULL");
+        return NULL;
+    }
+    fitsfile* fits = self->fits;
+    FITSfile* FITS = fits->Fptr;
+    // -> filehandle, driver
+    // -> filesize
+    // -> bytepos, io_pos
+    // cfileio.c : ffseek
+    // -> filesize, logfilesize
+
+    // memory driver: uses static memTable (drvrmem.c)
+    // file driver: uses static handleTable (drvrfile.c)
+
+    // mem_size etc get passed in fits_register_driver() calls
+    // -> populates driverTable[].size
+
+    int status = 0;
+
+    // Flush
+    //status = ffflushx(FITS);
+    // Flush, more vigorously
+    printf("ffflus\n");
+    ffflus(FITS, &status);
+    if (status) {
+        printf("Failed to flush FITS file data to disk; code %i\n", status);
+        Py_RETURN_NONE;
+    }
+
+    // ffflus
+    // ffflsh
+    // ffclos
+
+    LONGLONG sz = FITS->filesize;
+    printf("malloc %i\n", (int)sz);
+    // Allocate buffer for string
+    char* filedata = malloc(sz);
+    if (!filedata) {
+        printf("Failed to allocate memory (%i bytes) to copy file data\n", (int)sz);
+        Py_RETURN_NONE;
+    }
+
+    // Remember old file position
+    LONGLONG io_pos = FITS->io_pos;
+
+    // Seek to beginning of file
+    printf("seek\n");
+    if (ffseek(FITS, 0)) {
+        printf("Failed to seek to beginning of FITS file\n");
+        free(filedata);
+        Py_RETURN_NONE;
+    }
+
+    // Read into filedata
+    printf("read\n");
+    if (ffread(FITS, sz, filedata, &status)) {
+        printf("Failed to read file data into memory: code %i\n", status);
+        free(filedata);
+        Py_RETURN_NONE;
+    }
+
+    // Seek back to where we were
+    printf("seek %i\n", (int)io_pos);
+    if (ffseek(FITS, io_pos)) {
+        printf("Failed to seek back to original position\n");
+        free(filedata);
+        Py_RETURN_NONE;
+    }
+
+    return PyString_FromStringAndSize(filedata, sz);
+    // return PyByteArray_FromStringAndSize(filedata, sz);
+}
+
+
+
+
+
 static int get_long_slices(PyObject* fpix_arr,
                            PyObject* lpix_arr,
                            PyObject* step_arr,
@@ -3934,6 +4014,8 @@ static PyMethodDef PyFITSObject_methods[] = {
     {"movnam_hdu",           (PyCFunction)PyFITSObject_movnam_hdu,           METH_VARARGS,  "movnam_hdu\n\nMove to the specified HDU by name and return the hdu number."},
 
     {"get_hdu_info",         (PyCFunction)PyFITSObject_get_hdu_info,         METH_VARARGS,  "get_hdu_info\n\nReturn a dict with info about the specified HDU."},
+
+    {"read_raw",             (PyCFunction)PyFITSObject_read_raw,             METH_NOARGS,  "read_raw\n\nRead the entire raw contents of the FITS file, returning a python string OR 1-d numpy array of bytes."},
 
     {"read_image",           (PyCFunction)PyFITSObject_read_image,           METH_VARARGS,  "read_image\n\nRead the entire n-dimensional image array.  No checking of array is done."},
     {"read_image_slice",     (PyCFunction)PyFITSObject_read_image_slice,     METH_VARARGS,  "read_image_slice\n\nRead an image slice."},

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1386,6 +1386,11 @@ class HDUBase(object):
         # note converting strings
         return FITSHDR(self.read_header_list(), convert=True)
 
+    def read_raw(self):
+        """
+        Reads the raw FITS file contents, returning a Python string.
+        """
+        return self._FITS.read_raw()
 
     def read_header_list(self):
         """

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -772,6 +772,12 @@ class FITS(object):
 
         self[-1].write(data,names=names)
 
+    def read_raw(self):
+        """
+        Reads the raw FITS file contents, returning a Python string.
+        """
+        return self._FITS.read_raw()
+        
     def create_table_hdu(self, data=None, dtype=None, 
                          header=None,
                          names=None, formats=None,
@@ -1385,12 +1391,6 @@ class HDUBase(object):
         """
         # note converting strings
         return FITSHDR(self.read_header_list(), convert=True)
-
-    def read_raw(self):
-        """
-        Reads the raw FITS file contents, returning a Python string.
-        """
-        return self._FITS.read_raw()
 
     def read_header_list(self):
         """

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1611,7 +1611,7 @@ class TestReadWrite(unittest.TestCase):
                 fits.write(data)
                 raw2 = fits.read_raw()
 
-            f = open(fname, 'r')
+            f = open(fname, 'rb')
             raw3 = f.read()
             f.close()
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1593,6 +1593,34 @@ class TestReadWrite(unittest.TestCase):
             if os.path.exists(fname):
                 os.remove(fname)
 
+    def testReadRaw(self):
+        fname=tempfile.mktemp(prefix='fitsio-readraw-',suffix='.fits')
+
+        dt=[('MyName','f8'),('StuffThings','i4'),('Blah','f4')]
+        data=numpy.zeros(3, dtype=dt)
+        data['MyName'] = numpy.random.random(data.size)
+        data['StuffThings'] = numpy.random.random(data.size)
+        data['Blah'] = numpy.random.random(data.size)
+
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                fits.write(data)
+                raw1 = fits.read_raw()
+
+            with fitsio.FITS('mem://', 'rw') as fits:
+                fits.write(data)
+                raw2 = fits.read_raw()
+
+            f = open(fname, 'r')
+            raw3 = f.read()
+            f.close()
+
+            self.assertEqual(raw1, raw2)
+            self.assertEqual(raw1, raw3)
+        except:
+            import traceback
+            traceback.print_exc()
+            self.assertTrue(False, 'Exception in testing read_raw')
 
     def compare_names(self, read_names, true_names, lower=False, upper=False):
         for nread,ntrue in zip(read_names,true_names):


### PR DESCRIPTION
This PR adds a read_raw() method to the fitsio_pywrap.c FITS class.  It flushes data, copies the full file contents, and returns it as a Python string.

This should be particularly useful for "mem://" files.

This is motivated by a kind of weird use case where we want to catch filesystem corruption, so we do:

```
F = fitsio.FITS('mem://', 'rw')
F.write( ... )
rawdata = F.read_raw()
sha = hashlib.sha1()
sha.update(rawdata)
# remember sha.hexdigest()
f=open('F.fits', 'w')
f.write(rawdata)
f.close()
# Run sha1sum F.fits, compare against sha.hexdigest().
```
