### PR TITLE
Support fits_open_memfile/fits_create_memfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,37 @@ f[1].get_vstorage()         # for tables, storage mechanism for variable
 f[1].lower           # If True, lower case colnames on output
 f[1].upper           # If True, upper case colnames on output
 f[1].case_sensitive  # if True, names are matched case sensitive
+
+# Open a file in memory, using data you have already read in
+# through other alternative means (from the network, etc.).
+# The filename is ignored!
+bytes = bytearray(data_in_memory)
+f = FITS('inmemory.fits', 'r', bytes=bytes)
+f[0].read_header()
+
+# You can also create files directly in memory without writing them
+# to disk. This is useful if you are going to immediately send them
+# out over the network. There is no need to create the file on disk.
+bytes = bytearray(0)
+f = FITS('inmemory.fits', 'rw', bytes=bytes)
+f.write(data)
+
+# Now you can get the bytes in memory in two different ways. You can
+# use the read_raw() accessor function. This is useful if you're going
+# to add more data, but want to save a copy at this point.
+bytes = bytearray(0)
+f = FITS('inmemory.fits', 'rw', bytes=bytes)
+f.write(data)
+data = f.read_raw()
+print(len(data))
+
+# Or instead, you can close the file and use the byte array
+# that you used to construct the object.
+bytes = bytearray(0)
+f = FITS('inmemory.fits', 'rw', bytes=bytes)
+f.write(data)
+f.close()
+print(len(bytes))
 ```
 Installation
 ------------


### PR DESCRIPTION
It is occasionally useful to be able to use fitsio on files which you
have already read into memory through other means. The cfitsio library
supports this with fits_open_memfile/fits_create_memfile. Support is now
present for this method of operation.

This feature was developed with the use case of a thumbnail server in
mind. In our implementation, FITS files are received over HTTPS from the
network, immediately converted into a JPEG, and then sent out over HTTPS
to the client. By keeping everything in memory, the requests are
processed a little bit faster, and we don't need to worry about filling
up our disks with temporary files over time.

The implementation is somewhat suboptimal, because I could not find a
way in the Python interface that lets me use realloc() on a bytearray
(or similar Python object). Therefore, I had to create a copy of the
bytearray and use it instead, only copying back into the bytearray when
calling the close() method.

If we change this feature so that the only supported mode is read-only,
then this suboptimal behavior can go away (it becomes zero copy). **Zero
copy mode breaks the read_raw() accessor (SEGV in memcpy()). If I remove
zero copy mode and always copy, then everything I've tested works fine.**

**However, as an initial draft, I thought it would be beneficial to show
that we can do both read-only and read-write modes.**

Signed-off-by: Ira W. Snyder <isnyder@lco.global>