### PR TITLE
Support fits_open_memfile/fits_create_memfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ f[1].get_vstorage()         # for tables, storage mechanism for variable
 f[1].lower           # If True, lower case colnames on output
 f[1].upper           # If True, upper case colnames on output
 f[1].case_sensitive  # if True, names are matched case sensitive
+
+# Open a file in memory, using data you have already read in
+# through other alternative means (from the network, etc.).
+with FITSMemFile(bytearray(data_in_memory), 'r') as f:
+    f[0].read_header()
+
+# You can also create files directly in memory without writing them
+# to disk. This is useful if you are going to immediately send them
+# out over the network. There is no need to create the file on disk.
+with FITS('mem://', 'rw') as f:
+    f.write(data)
+    data_in_memory = f.read_raw()
 ```
 Installation
 ------------

--- a/fitsio/__init__.py
+++ b/fitsio/__init__.py
@@ -10,11 +10,13 @@ from . import fitslib
 from . import util
 
 from .fitslib import FITS
+from .fitslib import FITSMemFile
 from .fitslib import FITSHDR
 from .fitslib import FITSRecord
 from .fitslib import FITSCard
 
 from .fitslib import read
+from .fitslib import read_memfile
 from .fitslib import read_header
 from .fitslib import read_scamp_head
 from .fitslib import write


### PR DESCRIPTION
This is an alternate version of my previous pull request.

Rather than adding a parameter to the FITS class, we instead
create a FITSMemFile class which inherits almost everything from
the FITS class. This makes both implementations share the vast
majority of code, but keeps the differences between each implementation
separate and makes them easier to understand.

I also added a method to the test suite to make sure that the FITSMemFile
class is working as expected.