### PR TITLE
Treat CONTINUE card like COMMENT

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1271,6 +1271,12 @@ class HDUBase(object):
         """
         self._FITS.write_history(self._ext+1, str(history))
 
+    def write_continue(self, value):
+        """
+        Write history text into the header
+        """
+        self._FITS.write_continue(self._ext+1, str(value))
+
     def write_key(self, keyname, value, comment=""):
         """
         Write the input value to the header
@@ -1377,6 +1383,8 @@ class HDUBase(object):
                 self.write_comment(value)
             elif name=='HISTORY':
                 self.write_history(value)
+            elif name=='CONTINUE':
+                self.write_continue(value)
             else:
                 comment=r.get('comment','')
                 self.write_key(name,value,comment=comment)
@@ -3859,7 +3867,7 @@ class FITSHDR(object):
 
         key_exists = key in self._record_map
 
-        if not key_exists or key == 'COMMENT' or key == 'HISTORY':
+        if not key_exists or key in ('COMMENT','HISTORY','CONTINUE'):
             # append new record
             self._record_list.append(record)
             index=len(self._record_list)-1
@@ -4087,6 +4095,8 @@ class FITSHDR(object):
 
         if name == 'COMMENT':
             card = 'COMMENT   %s' % value
+        elif name == 'CONTINUE':
+            card = 'CONTINUE   %s' % value
         elif name=='HISTORY':
             card = 'HISTORY   %s' % value
         else:
@@ -4298,11 +4308,13 @@ class FITSCard(FITSRecord):
             front=card_string[0:7]
             if (not self.has_equals() or front=='COMMENT' or front=='HISTORY'):
 
-                if front=='CONTINU':
-                    raise ValueError("CONTINUE not supported")
+                #if front=='CONTINU':
+                #    raise ValueError("CONTINUE not supported")
 
                 if front=='HISTORY':
                     self._set_as_history()
+                elif front=='CONTINU':
+                    self._set_as_continue()
                 else:
                     # note anything without an = and not history is
                     # treated as comment; this is built into cfitsio
@@ -4341,7 +4353,7 @@ class FITSCard(FITSRecord):
         res=_fitsio_wrap.parse_card(card_string)
         keyclass, name, value, dtype, comment=res
 
-        if keyclass==140:
+        if keyclass==TYP_CONT_KEY:
             raise ValueError("bad card '%s'.  CONTINUE not "
                              "supported" % card_string)
 
@@ -4365,6 +4377,13 @@ class FITSCard(FITSRecord):
         self['class'] = TYP_COMM_KEY
         self['name']  = 'HISTORY'
         self['value'] =  history
+
+    def _set_as_continue(self):
+        value=self._extract_comm_or_hist_value()
+
+        self['class'] = TYP_CONT_KEY
+        self['name']  = 'CONTINUE'
+        self['value'] =  value
 
     def _extract_comm_or_hist_value(self):
         card_string=self['card_string']

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1271,7 +1271,7 @@ class HDUBase(object):
         """
         self._FITS.write_history(self._ext+1, str(history))
 
-    def write_continue(self, value):
+    def _write_continue(self, value):
         """
         Write history text into the header
         """
@@ -1384,7 +1384,7 @@ class HDUBase(object):
             elif name=='HISTORY':
                 self.write_history(value)
             elif name=='CONTINUE':
-                self.write_continue(value)
+                self._write_continue(value)
             else:
                 comment=r.get('comment','')
                 self.write_key(name,value,comment=comment)

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -321,6 +321,34 @@ class TestReadWrite(unittest.TestCase):
             if os.path.exists(fname):
                 pass
                 #os.remove(fname)
+
+    def testHeaderContinue(self):
+        """
+        Test a header with CONTINUE keys
+        """
+        fname=tempfile.mktemp(prefix='fitsio-HeaderContinue-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                data=numpy.zeros(10)
+                header = [                          
+                    "SVALUE  = 'This is a long string value &' ",
+                    "CONTINUE  'extending&   '   ",
+                    "CONTINUE  ' over 3 lines.'     / and a comment ",
+                    "TEST    = 10 / another key",
+                    ]
+                fits.write_image(data, header=header)
+
+                rh = fits[0].read_header()
+                assert rh.keys().count('CONTINUE') == 2
+                
+            with fitsio.FITS(fname) as fits:
+                rh = fits[0].read_header()
+                assert rh.keys().count('CONTINUE') == 2
+
+        finally:
+            if os.path.exists(fname):
+                pass
+                #os.remove(fname)
  
     def testImageWriteRead(self):
         """


### PR DESCRIPTION
This PR closes #117 by treating `CONTINUE` cards like `COMMENT` cards. This is not a full implementation of the `CONTINUE` convention documented [here](https://fits.gsfc.nasa.gov/registry/continue_keyword.html), which is left to be addressed by #118.