### PR TITLE
Support read-only in memory files (using fits_open_memfile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ f[1].get_vstorage()         # for tables, storage mechanism for variable
 f[1].lower           # If True, lower case colnames on output
 f[1].upper           # If True, upper case colnames on output
 f[1].case_sensitive  # if True, names are matched case sensitive
+
+# Open a file in memory, using data you have already read in
+# through other alternative means (from the network, etc.).
+with FITSMemFile(bytearray(data_in_memory), 'r') as f:
+    f[0].read_header()
+
+# You can also create files directly in memory without writing them
+# to disk. This is useful if you are going to immediately send them
+# out over the network. There is no need to create the file on disk.
+with FITS('mem://', 'rw') as f:
+    f.write(data)
+    data_in_memory = f.read_raw()
 ```
 Installation
 ------------

--- a/fitsio/__init__.py
+++ b/fitsio/__init__.py
@@ -10,11 +10,13 @@ from . import fitslib
 from . import util
 
 from .fitslib import FITS
+from .fitslib import FITSMemFile
 from .fitslib import FITSHDR
 from .fitslib import FITSRecord
 from .fitslib import FITSCard
 
 from .fitslib import read
+from .fitslib import read_memfile
 from .fitslib import read_header
 from .fitslib import read_scamp_head
 from .fitslib import write


### PR DESCRIPTION
It is occasionally useful to be able to use fitsio on files which you
have already read into memory through other means. The cfitsio library
supports this with fits_open_memfile/fits_create_memfile.

This feature was developed with the use case of a thumbnail server in
mind. In our implementation, FITS files are received over HTTPS from the
network, immediately converted into a JPEG, and then sent out over HTTPS
to the client. By keeping everything in memory, the requests are
processed a little bit faster, and we don't need to worry about filling
up our disks with temporary files over time.

To keep the code simple, we have exclusively implemented support for
read-only operation using fits_open_memfile. The existing implementation
can already create temporary FITS files in memory, and then retrieve the
raw bytes. This implementation adds support for taking bytes in memory
and turning them into a FITS object.

Signed-off-by: Ira W. Snyder <isnyder@lco.global>