### PR TITLE
Adds support for column and keyword filtering specification

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -348,6 +348,10 @@ class FITS(object):
                     create=0
                 else:
                     create=1
+        elif self.mode in [READONLY, 'r']:
+            explicitfilename = filename.split("[")[0]
+            if not os.path.exists(explicitfilename):
+                raise IOError("File not found: '%s'" % explicitfilename)
         else:
             if not os.path.exists(filename):
                 raise IOError("File not found: '%s'" % filename)


### PR DESCRIPTION
In the current form, the python wrapper does not support column and keyword filtering specification (see https://heasarc.gsfc.nasa.gov/fitsio/c/c_user/node96.html). The code raises an IOError for "File not found" if column and keyword filtering are specified in the filename.

I have added a small fix which would extend the functionality of the python wrapper. If the file is read only then the new code strips out the column and keyword filtering specification before checking whether the file exists on disk.

Example based on atestfil.fit created by cookbook.c:

```python
import fitsio
fp = fitsio.FITS("atestfil.fit[1][col *, newcolname = Planet]")[1]
print fp.get_colnames()
```

This will output:
```bash
['Planet', 'Diameter', 'Density', 'newcolname']
```

The code will now add a new column newcolname whose value equals that in the column Planet. The column and keyword filtering specification allows a number of operations to be performed including deleting columns, and common arithmetic operations as listed in the link I posted above.
