### PR TITLE
Add test of real DES header with CONTINUE= and fix to work.

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -4382,7 +4382,7 @@ class FITSCard(FITSRecord):
             self._check_len()
 
             front=card_string[0:7]
-            if (not self.has_equals() or front=='COMMENT' or front=='HISTORY'):
+            if (not self.has_equals() or front in ['COMMENT', 'HISTORY', 'CONTINU']):
 
                 #if front=='CONTINU':
                 #    raise ValueError("CONTINUE not supported")

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -4384,9 +4384,6 @@ class FITSCard(FITSRecord):
             front=card_string[0:7]
             if (not self.has_equals() or front in ['COMMENT', 'HISTORY', 'CONTINU']):
 
-                #if front=='CONTINU':
-                #    raise ValueError("CONTINUE not supported")
-
                 if front=='HISTORY':
                     self._set_as_history()
                 elif front=='CONTINU':
@@ -4396,6 +4393,13 @@ class FITSCard(FITSRecord):
                     # treated as comment; this is built into cfitsio
                     # as well
                     self._set_as_comment()
+
+                if self.has_equals():
+                    mess=("warning: It is not FITS-compliant for a %s header card to include "
+                          "an = sign.  There may be slight inconsistencies if you write this "
+                          "back out to a file.")
+                    mess = mess % (card_string[:8])
+                    warnings.warn(mess, FITSRuntimeWarning)
             else:
                 self._set_as_key()
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -380,8 +380,12 @@ class TestReadWrite(unittest.TestCase):
                     "OBSERVER= 'Ross Cawthon(RM), Ricardo Ogando(OBS1), Rutu Das (OBS1) Michael &'",
                     "CONTINUE= '        '           /   '&' / Observer name(s)",
                     ]
-                fits.write_image(data, header=header)
+                numpy.testing.assert_warns(fitsio.FITSRuntimeWarning,
+                                           fits.write_image, data, header=header)
 
+                # The CONTINUE= line gets converted to a normal CONTINUE, so no warning on reads.
+                # There would be a warning if the file being read has CONTINUE=, but that would
+                # be harder to test explicitly, since fitsio won't write that file...
                 rh = fits[0].read_header()
                 assert rh.keys().count('CONTINUE') == 1
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -376,7 +376,7 @@ class TestReadWrite(unittest.TestCase):
                 data=numpy.zeros(10)
                 header = [
                     # This is a snippet from a real DES FITS header, which (I guess incorrectly)
-                    # puts # an = sign after the CONTINUE.  This didn't used to work.
+                    # puts an = sign after the CONTINUE.  This didn't used to work.
                     "OBSERVER= 'Ross Cawthon(RM), Ricardo Ogando(OBS1), Rutu Das (OBS1) Michael &'",
                     "CONTINUE= '        '           /   '&' / Observer name(s)",
                     ]

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -371,6 +371,32 @@ class TestReadWrite(unittest.TestCase):
             if os.path.exists(fname):
                 pass
                 #os.remove(fname)
+
+        fname=tempfile.mktemp(prefix='fitsio-HeaderContinue-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                data=numpy.zeros(10)
+                header = [
+                    # This is a snippet from a real DES FITS header, which (I guess incorrectly)
+                    # puts # an = sign after the CONTINUE.  This didn't used to work.
+                    "OBSERVER= 'Ross Cawthon(RM), Ricardo Ogando(OBS1), Rutu Das (OBS1) Michael &'",
+                    "CONTINUE= '        '           /   '&' / Observer name(s)",
+                    ]
+                fits.write_image(data, header=header)
+
+                rh = fits[0].read_header()
+                assert rh.keys().count('CONTINUE') == 1
+
+            with fitsio.FITS(fname) as fits:
+                rh = fits[0].read_header()
+                assert rh.keys().count('CONTINUE') == 1
+
+        finally:
+            if os.path.exists(fname):
+                pass
+                #os.remove(fname)
+
+
  
     def testImageWriteRead(self):
         """

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -341,8 +341,7 @@ class TestReadWrite(unittest.TestCase):
 
         finally:
             if os.path.exists(fname):
-                pass
-                #os.remove(fname)
+                os.remove(fname)
 
     def testHeaderContinue(self):
         """
@@ -369,8 +368,7 @@ class TestReadWrite(unittest.TestCase):
 
         finally:
             if os.path.exists(fname):
-                pass
-                #os.remove(fname)
+                os.remove(fname)
 
         fname=tempfile.mktemp(prefix='fitsio-HeaderContinue-',suffix='.fits')
         try:
@@ -393,8 +391,7 @@ class TestReadWrite(unittest.TestCase):
 
         finally:
             if os.path.exists(fname):
-                pass
-                #os.remove(fname)
+                os.remove(fname)
 
 
  


### PR DESCRIPTION
I was running into some errors when reading DES Y3 fits files that had "CONTINUE=" lines (rather than CONTINUE with out the =).  I don't know if this is FITS-standard-conforming or not, but it seems like it is worth fitsio supporting this syntax.