### PR TITLE
preserve strings with underscores as strings

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -4462,11 +4462,15 @@ class FITSRecord(dict):
             if isinstance(avalue,ast.BinOp):
                 # this is probably a string that happens to look like
                 # a binary operation, e.g. '25-3'
-                value = orig_value
+                value = value_orig
             else:
                 value = ast.literal_eval(value_orig)
         except:
             value = self._convert_quoted_string(value_orig)
+
+        if isinstance(value,int) and '_' in value_orig:
+            value = value_orig
+
         return value
 
     def _convert_quoted_string(self, value):

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -330,6 +330,8 @@ class TestReadWrite(unittest.TestCase):
                                     #like expressions
                     'name':'J. Smith',
                     'und':None,
+                    'binop':'25-3', # test string with binary operation in it
+                    'unders':'1_000_000', # test string with underscore
                 }
                 fits.write_image(data, header=header)
 


### PR DESCRIPTION
These were being converted to integers in py3: '1_000_000'

add tests for this and the binary operation '25-3' case

fix bug with binary op case setting wrong value

addressed #167 