### PR TITLE
Fix long string reading in FITS headers

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -3982,7 +3982,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
     long is_string_value=0;
 
     int nkeys=0, morekeys=0, i=0;
-    int has_equals=0;
+    int has_equals=0, has_quote=0;
 
     PyObject* list=NULL;
     PyObject* dict=NULL;  // to hold the dict for each record
@@ -4026,14 +4026,12 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
             return NULL;
         }
 
-        // skip CONTINUE unless there is an = sign which may indicate a corrupt
-        // continue
-        has_equals = (card[8] == '=') ? 1 : 0;
 
         ls=strlen(keyname);
         tocomp = (ls < lcont) ? ls : lcont;
 
-        if (!has_equals && strncmp(keyname,"CONTINUE",tocomp)==0) {
+        // skip CONTINUE, we already read the data
+        if (strncmp(keyname,"CONTINUE",tocomp)==0) {
             continue;
         }
 
@@ -4043,7 +4041,9 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
             return NULL;
         }
 
-        if (has_equals && card[10]=='\'') {
+        has_equals = (card[8] == '=') ? 1 : 0;
+        has_quote = (card[10] == '\'') ? 1 : 0;
+        if (has_equals && has_quote) {
             is_string_value=1;
         } else {
             is_string_value=0;

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1475,8 +1475,8 @@ PyFITSObject_write_image(struct PyFITSObject* self, PyObject* args) {
  */
 static int 
 add_tdims_from_listobj(fitsfile* fits, PyObject* tdimObj, int ncols) {
-    int status=0;
-    size_t size=0, i=0;
+    int status=0, i=0;
+    size_t size=0;
     char keyname[20];
     int colnum=0;
     PyObject* tmp=NULL;
@@ -1493,7 +1493,7 @@ add_tdims_from_listobj(fitsfile* fits, PyObject* tdimObj, int ncols) {
     }
 
     size = PyList_Size(tdimObj);
-    if (size != ncols) {
+    if (size != (size_t)ncols) {
         PyErr_Format(PyExc_ValueError, "Expected %d elements in tdims list, got %ld", ncols, size);
         return 1;
     }
@@ -2558,7 +2558,6 @@ PyFITSObject_write_undefined_key(struct PyFITSObject* self, PyObject* args) {
     int hdutype=0;
 
     char* keyname=NULL;
-    int value=0;
     char* comment=NULL;
     char* comment_in=NULL;
  
@@ -3972,7 +3971,6 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
     int status=0;
     int hdunum=0;
     int hdutype=0;
-    char *tmp=NULL;
     int lcont=0, lcomm=0, ls=0;
     int tocomp=0;
     char *longstr=NULL;

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4056,7 +4056,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
             add_string_to_dict(dict,"value",longstr);
         }
 
-        free(longstr);
+        free(longstr); longstr=NULL;
 
         PyList_Append(list, dict);
         Py_XDECREF(dict);

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4050,7 +4050,10 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
 
         // if not a comment but empty value, put in None
         tocomp = (ls < lcomm) ? ls : lcomm;
-        if (0==strlen(longstr) && strncmp(keyname,"COMMENT",tocomp)!=0) {
+        if (!is_string_value
+                && 0==strlen(longstr)
+                && strncmp(keyname,"COMMENT",tocomp)!=0) {
+
             add_none_to_dict(dict, "value");
         } else {
             add_string_to_dict(dict,"value",longstr);

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -3982,6 +3982,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
     long is_string_value=0;
 
     int nkeys=0, morekeys=0, i=0;
+    int has_equals=0;
 
     PyObject* list=NULL;
     PyObject* dict=NULL;  // to hold the dict for each record
@@ -4024,9 +4025,15 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
+
+        // skip CONTINUE unless there is an = sign which may indicate a corrupt
+        // continue
+        has_equals = (card[8] == '=') ? 1 : 0;
+
         ls=strlen(keyname);
         tocomp = (ls < lcont) ? ls : lcont;
-        if (strncmp(keyname,"CONTINUE",tocomp)==0) {
+
+        if (!has_equals && strncmp(keyname,"CONTINUE",tocomp)==0) {
             continue;
         }
 
@@ -4036,7 +4043,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
             return NULL;
         }
 
-        if (card[8]=='=' && card[10]=='\'') {
+        if (has_equals && card[10]=='\'') {
             is_string_value=1;
         } else {
             is_string_value=0;

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -496,24 +496,25 @@ class TestReadWrite(unittest.TestCase):
         test generating a header from cards, writing it out and getting
         back what we put in
         """
-        hdr_from_cards=fitsio.FITSHDR([
-            "IVAL    =                   35 / integer value                                  ",
-            "SHORTS  = 'hello world'                                                         ",
-            "CONTINUE= '        '           /   '&' / Current observing orogram              ",
-            "UND     =                                                                       ",
-            "DBL     =                 1.25                                                  ",
-        ]).records()
-        header = fitsio.FITSHDR([
-            {'name':'ival','value':35,'comment':'integer value'},
-            {'name':'shorts','value':'hello world'},
-            {'name':'continue','value':'','comment':"  '&' / Current observing orogram"},
-            {'name':'und','value':None},
-            {'name':'dbl','value':1.25},
-        ]).records()
+        with warnings.catch_warnings(record=True) as w:
+            hdr_from_cards=fitsio.FITSHDR([
+                "IVAL    =                   35 / integer value                                  ",
+                "SHORTS  = 'hello world'                                                         ",
+                "CONTINUE= '        '           /   '&' / Current observing orogram              ",
+                "UND     =                                                                       ",
+                "DBL     =                 1.25                                                  ",
+            ]).records()
+            header = fitsio.FITSHDR([
+                {'name':'ival','value':35,'comment':'integer value'},
+                {'name':'shorts','value':'hello world'},
+                {'name':'continue','value':'','comment':"  '&' / Current observing orogram"},
+                {'name':'und','value':None},
+                {'name':'dbl','value':1.25},
+            ]).records()
 
-        
-        self.assertEqual(len(hdr_from_cards), len(header),
-                         "headers must be same length")
+            
+            self.assertEqual(len(hdr_from_cards), len(header),
+                             "headers must be same length")
 
 
     def testImageWriteRead(self):

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -491,6 +491,30 @@ class TestReadWrite(unittest.TestCase):
             if os.path.exists(fname):
                 os.remove(fname)
 
+    def testCorruptContinue(self):
+        """
+        test generating a header from cards, writing it out and getting
+        back what we put in
+        """
+        hdr_from_cards=fitsio.FITSHDR([
+            "IVAL    =                   35 / integer value                                  ",
+            "SHORTS  = 'hello world'                                                         ",
+            "CONTINUE= '        '           /   '&' / Current observing orogram              ",
+            "UND     =                                                                       ",
+            "DBL     =                 1.25                                                  ",
+        ]).records()
+        header = fitsio.FITSHDR([
+            {'name':'ival','value':35,'comment':'integer value'},
+            {'name':'shorts','value':'hello world'},
+            {'name':'continue','value':'','comment':"  '&' / Current observing orogram"},
+            {'name':'und','value':None},
+            {'name':'dbl','value':1.25},
+        ]).records()
+
+        
+        self.assertEqual(len(hdr_from_cards), len(header),
+                         "headers must be same length")
+
 
     def testImageWriteRead(self):
         """

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -537,8 +537,6 @@ class TestReadWrite(unittest.TestCase):
 
                 rhdr = fitsio.read_header(fname)
 
-                import pdb; pdb.set_trace()
-                
             finally:
                 if os.path.exists(fname):
                     os.remove(fname)

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -517,6 +517,33 @@ class TestReadWrite(unittest.TestCase):
                 if os.path.exists(fname):
                     os.remove(fname)
 
+        with warnings.catch_warnings(record=True) as w:
+            fname=tempfile.mktemp(prefix='fitsio-TestCorruptContinue-',suffix='.fits')
+
+            hdr_from_cards=fitsio.FITSHDR([
+                "IVAL    =                   35 / integer value                                  ",
+                "SHORTS  = 'hello world'                                                         ",
+                "PROGRAM = 'Setting the Scale: Determining the Absolute Mass Normalization and &'",
+                "CONTINUE  'Scaling Relations for Clusters at z~0.1&'                            ",
+                "CONTINUE  '&' / Current observing orogram                                       ",
+                "UND     =                                                                       ",
+                "DBL     =                 1.25                                                  ",
+            ])
+
+            try:
+                with fitsio.FITS(fname,'rw',clobber=True) as fits:
+
+                    fits.write(None, header=hdr_from_cards)
+
+                rhdr = fitsio.read_header(fname)
+
+                import pdb; pdb.set_trace()
+                
+            finally:
+                if os.path.exists(fname):
+                    os.remove(fname)
+
+
     def testImageWriteRead(self):
         """
         Test a basic image write, data and a header, then reading back in to

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -216,6 +216,7 @@ class TestReadWrite(unittest.TestCase):
 
         # use a dict list so we can have comments
         self.keys = [{'name':'test1','value':35},
+                     {'name':'empty','value':''},
                      {'name':'test2','value':'stuff','comment':'this is a string keyword'},
                      {'name':'dbl', 'value':23.299843,'comment':"this is a double keyword"},
                      {'name':'lng','value':3423432,'comment':'this is a long keyword'},
@@ -414,6 +415,7 @@ class TestReadWrite(unittest.TestCase):
                 header={
                     'x':35,
                     'y':88.215,
+                    'empty':'',
                     'funky':'35-8', # test old bug when strings look
                                     #like expressions
                     'name':'J. Smith',

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -493,29 +493,29 @@ class TestReadWrite(unittest.TestCase):
 
     def testCorruptContinue(self):
         """
-        test generating a header from cards, writing it out and getting
-        back what we put in
+        test with corrupt continue, just make sure it doesn't crash
         """
         with warnings.catch_warnings(record=True) as w:
+            fname=tempfile.mktemp(prefix='fitsio-TestCorruptContinue-',suffix='.fits')
+
             hdr_from_cards=fitsio.FITSHDR([
                 "IVAL    =                   35 / integer value                                  ",
                 "SHORTS  = 'hello world'                                                         ",
                 "CONTINUE= '        '           /   '&' / Current observing orogram              ",
                 "UND     =                                                                       ",
                 "DBL     =                 1.25                                                  ",
-            ]).records()
-            header = fitsio.FITSHDR([
-                {'name':'ival','value':35,'comment':'integer value'},
-                {'name':'shorts','value':'hello world'},
-                {'name':'continue','value':'','comment':"  '&' / Current observing orogram"},
-                {'name':'und','value':None},
-                {'name':'dbl','value':1.25},
-            ]).records()
+            ])
 
-            
-            self.assertEqual(len(hdr_from_cards), len(header),
-                             "headers must be same length")
+            try:
+                with fitsio.FITS(fname,'rw',clobber=True) as fits:
 
+                    fits.write(None, header=hdr_from_cards)
+
+                rhdr = fitsio.read_header(fname)
+
+            finally:
+                if os.path.exists(fname):
+                    os.remove(fname)
 
     def testImageWriteRead(self):
         """


### PR DESCRIPTION
long strings are read correctly (via CONTINUE)

now all keyword values are read into long strings and converted in the python code.