### PR TITLE
fix EXTNAME case comparison in read_header()

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -169,7 +169,7 @@ def read_header(filename, ext=0, extver=None, case_sensitive=False, **keys):
                 try:
                     hdu_type = _fits.movabs_hdu(hdunum)  # noqa - not used
                     name, vers = _fits.get_hdu_name_version(hdunum)
-                    if name == extname_low:
+                    if name.lower() == extname_low:
                         if extver is None:
                             # take the first match
                             found = True


### PR DESCRIPTION
This PR fixes a bug in `fitsio.read_header()` where it was comparing a capitalized EXTNAME to a previously lower-cased extname, and thus not finding the HDU.  Attached is a gzip-ed file for testing if you want to try a different solution.

Current master:
```
$> python -c "import fitsio; fitsio.read_header('cmx-targets.fits', 'TARGETS')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/sbailey/anaconda3/envs/fitsiotest/lib/python3.7/site-packages/fitsio-1.0.1-py3.7-macosx-10.7-x86_64.egg/fitsio/fitslib.py", line 188, in read_header
    'hdu not found: %s (extver %s)' % (extname, extver))
OSError: hdu not found: TARGETS (extver None)
```

With this PR:
```
$> python -c "import fitsio; fitsio.read_header('cmx-targets.fits', 'TARGETS')"
[no error]
```


[cmx-targets.fits.gz](https://github.com/esheldon/fitsio/files/3123268/cmx-targets.fits.gz)
