### PR TITLE
fixes for writing comments with blank keywords

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4194,15 +4194,6 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
             add_none_to_dict(dict,"name");
             add_string_to_dict(dict,"value","");
             add_string_to_dict(dict,"comment",comment);
-            // cfitsio adds an extra space when the comment is
-            // not blank
-            /*
-            if (strlen(comment)==0) {
-                add_string_to_dict(dict,"comment","");
-            } else {
-                add_string_to_dict(dict,"comment",&comment[1]);
-            }
-            */
         } else {
             add_string_to_dict(dict,"name",keyname);
             add_string_to_dict(dict,"comment",comment);

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4193,12 +4193,16 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
         if (is_blank_key) {
             add_none_to_dict(dict,"name");
             add_string_to_dict(dict,"value","");
-            // cfitsio adds an extra space
+            add_string_to_dict(dict,"comment",comment);
+            // cfitsio adds an extra space when the comment is
+            // not blank
+            /*
             if (strlen(comment)==0) {
                 add_string_to_dict(dict,"comment","");
             } else {
                 add_string_to_dict(dict,"comment",&comment[1]);
             }
+            */
         } else {
             add_string_to_dict(dict,"name",keyname);
             add_string_to_dict(dict,"comment",comment);

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -198,7 +198,24 @@ class HDUBase(object):
         methods
         """
 
-        if value is None:
+        if name is None:
+
+            # we write a blank keyword and the rest is a comment
+            # string
+
+            if not isinstance(value, _stypes):
+                raise ValueError('when writing blank key the value '
+                                 'must be a string')
+
+            # this might be longer than 80 but that's ok, the routine
+            # will take care of it
+            card = '         ' + str(value)
+            self._FITS.write_record(
+                self._ext+1,
+                card,
+            )
+
+        elif value is None:
             self._FITS.write_undefined_key(self._ext+1,
                                            str(name),
                                            str(comment))
@@ -281,7 +298,10 @@ class HDUBase(object):
             hdr.clean(is_table=is_table)
 
         for r in hdr.records():
-            name = r['name'].upper()
+            name = r['name']
+            if name is not None:
+                name = name.upper()
+
             value = r['value']
 
             if name == 'COMMENT':

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -203,13 +203,14 @@ class HDUBase(object):
             # we write a blank keyword and the rest is a comment
             # string
 
-            if not isinstance(value, _stypes):
+            if not isinstance(comment, _stypes):
                 raise ValueError('when writing blank key the value '
                                  'must be a string')
 
             # this might be longer than 80 but that's ok, the routine
             # will take care of it
-            card = '         ' + str(comment)
+            # card = '         ' + str(comment)
+            card = '        ' + str(comment)
             self._FITS.write_record(
                 self._ext+1,
                 card,

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -209,7 +209,7 @@ class HDUBase(object):
 
             # this might be longer than 80 but that's ok, the routine
             # will take care of it
-            card = '         ' + str(value)
+            card = '         ' + str(comment)
             self._FITS.write_record(
                 self._ext+1,
                 card,

--- a/fitsio/header.py
+++ b/fitsio/header.py
@@ -151,7 +151,7 @@ class FITSHDR(object):
 
         key_exists = key in self._record_map
 
-        if not key_exists or key in ('COMMENT', 'HISTORY', 'CONTINUE',None):
+        if not key_exists or key in ('COMMENT', 'HISTORY', 'CONTINUE', None):
             # append new record
             self._record_list.append(record)
             index = len(self._record_list)-1
@@ -383,7 +383,7 @@ class FITSHDR(object):
         """
         name = record['name']
         value = record['value']
-        comment = record.get('comment','')
+        comment = record.get('comment', '')
 
         v_isstring = isstring(value)
 
@@ -515,7 +515,9 @@ class FITSRecord(dict):
         if 'value' not in self:
             raise ValueError("each record must have a 'value' field")
 
-_blank = '       '
+
+_BLANK = '       '
+
 
 class FITSCard(FITSRecord):
     """
@@ -547,18 +549,18 @@ class FITSCard(FITSRecord):
 
             front = card_string[0:7]
             if (not self.has_equals() or
-                    front in ['COMMENT', 'HISTORY', 'CONTINU',_blank]):
+                    front in ['COMMENT', 'HISTORY', 'CONTINU', _BLANK]):
 
                 if front == 'HISTORY':
                     self._set_as_history()
                 elif front == 'CONTINU':
                     self._set_as_continue()
-                elif front == _blank:
+                elif front == _BLANK:
                     self._set_as_blank()
                 else:
-                    # note anything without an = and not history is
-                    # treated as comment; this is built into cfitsio
-                    # as well
+                    # note anything without an = and not history and not blank
+                    # key comment is treated as COMMENT; this is built into
+                    # cfitsio as well
                     self._set_as_comment()
 
                 if self.has_equals():

--- a/fitsio/header.py
+++ b/fitsio/header.py
@@ -145,11 +145,13 @@ class FITSHDR(object):
 
         # only append when this name already exists if it is
         # a comment or history field, otherwise simply over-write
-        key = record['name'].upper()
+        key = record['name']
+        if key is not None:
+            key = key.upper()
 
         key_exists = key in self._record_map
 
-        if not key_exists or key in ('COMMENT', 'HISTORY', 'CONTINUE'):
+        if not key_exists or key in ('COMMENT', 'HISTORY', 'CONTINUE',None):
             # append new record
             self._record_list.append(record)
             index = len(self._record_list)-1
@@ -384,7 +386,9 @@ class FITSHDR(object):
 
         v_isstring = isstring(value)
 
-        if name == 'COMMENT':
+        if name is None:
+            card = '         %s' % value
+        elif name == 'COMMENT':
             # card = 'COMMENT   %s' % value
             card = 'COMMENT %s' % value
         elif name == 'CONTINUE':

--- a/fitsio/header.py
+++ b/fitsio/header.py
@@ -515,6 +515,7 @@ class FITSRecord(dict):
         if 'value' not in self:
             raise ValueError("each record must have a 'value' field")
 
+_blank = '       '
 
 class FITSCard(FITSRecord):
     """
@@ -546,12 +547,14 @@ class FITSCard(FITSRecord):
 
             front = card_string[0:7]
             if (not self.has_equals() or
-                    front in ['COMMENT', 'HISTORY', 'CONTINU']):
+                    front in ['COMMENT', 'HISTORY', 'CONTINU',_blank]):
 
                 if front == 'HISTORY':
                     self._set_as_history()
                 elif front == 'CONTINU':
                     self._set_as_continue()
+                elif front == _blank:
+                    self._set_as_blank()
                 else:
                     # note anything without an = and not history is
                     # treated as comment; this is built into cfitsio
@@ -613,6 +616,12 @@ class FITSCard(FITSRecord):
         self['value'] = self._convert_value(value)
         self['dtype'] = dtype
         self['comment'] = comment
+
+    def _set_as_blank(self):
+        self['class'] = TYP_USER_KEY
+        self['name'] = None
+        self['value'] = None
+        self['comment'] = self['card_string'][9:]
 
     def _set_as_comment(self):
         comment = self._extract_comm_or_hist_value()

--- a/fitsio/header.py
+++ b/fitsio/header.py
@@ -383,14 +383,14 @@ class FITSHDR(object):
         """
         name = record['name']
         value = record['value']
+        comment = record.get('comment','')
 
         v_isstring = isstring(value)
 
         if name is None:
-            card = '         %s' % value
+            card = '         %s' % comment
         elif name == 'COMMENT':
-            # card = 'COMMENT   %s' % value
-            card = 'COMMENT %s' % value
+            card = 'COMMENT %s' % comment
         elif name == 'CONTINUE':
             card = 'CONTINUE   %s' % value
         elif name == 'HISTORY':
@@ -415,6 +415,11 @@ class FITSHDR(object):
                 else:
                     vstr = "''"
             else:
+                if value is True:
+                    value = 'T'
+                elif value is False:
+                    value = 'F'
+
                 vstr = '%20s' % value
 
             card += vstr

--- a/fitsio/header.py
+++ b/fitsio/header.py
@@ -621,7 +621,7 @@ class FITSCard(FITSRecord):
         self['class'] = TYP_USER_KEY
         self['name'] = None
         self['value'] = None
-        self['comment'] = self['card_string'][9:]
+        self['comment'] = self['card_string'][8:]
 
     def _set_as_comment(self):
         comment = self._extract_comm_or_hist_value()

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -547,6 +547,7 @@ class TestReadWrite(unittest.TestCase):
                 records = [
                     '                                                                                ',
                     '         --- testing comment ---                                                ',
+                    '        --- testing comment ---                                                 ',
                     "COMMENT testing                                                                 ",
                 ]
                 header = fitsio.FITSHDR(records)
@@ -556,6 +557,9 @@ class TestReadWrite(unittest.TestCase):
                 rh = fits[0].read_header()
 
                 rrecords = rh.records()
+                from pprint import pprint
+                print()
+                pprint(rrecords)
 
                 self.assertEqual(
                     rrecords[6]['name'],
@@ -574,9 +578,20 @@ class TestReadWrite(unittest.TestCase):
                 )
                 self.assertEqual(
                     rrecords[7]['comment'],
+                    ' --- testing comment ---',
+                    "check empty key comment",
+                )
+                self.assertEqual(
+                    rrecords[8]['name'],
+                    None,
+                    'checking name is None',
+                )
+                self.assertEqual(
+                    rrecords[8]['comment'],
                     '--- testing comment ---',
                     "check empty key comment",
                 )
+
 
                 self.assertEqual(
                     rrecords[5]['name'],

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -486,6 +486,57 @@ class TestReadWrite(unittest.TestCase):
         self.assertEqual(hdr.get_comment('key1'), 'My comment1',
                          'comment not preserved')
 
+    def testBlankKeyComments(self):
+        """
+        test a few different comments
+        """
+
+        fname=tempfile.mktemp(prefix='fitsio-HeaderComments-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                records = [
+                    # empty should return empty
+                    {'name':None, 'value':'', 'comment':''},
+                    # this will also return empty
+                    {'name':None, 'value':'', 'comment':' '},
+                    # this will return exactly
+                    {'name':None, 'value':'', 'comment':' h'},
+                    # this will return exactly
+                    {'name':None, 'value':'', 'comment':'--- test comment ---'},
+                ]
+                header = fitsio.FITSHDR(records)
+
+                fits.write(None, header=header)
+
+                rh = fits[0].read_header()
+
+                rrecords = rh.records()
+
+                for i, ri in ((0, 6), (1,7), (2, 8)):
+                    rec = records[i]
+                    rrec = rrecords[ri]
+
+                    self.assertEqual(
+                        rec['name'],
+                        None,
+                        'checking comment is called COMMENT',
+                    )
+                    comment = rec['comment']
+                    rcomment = rrec['comment']
+                    if '' == comment.strip():
+                        comment = ''
+
+                    self.assertEqual(
+                        comment,
+                        rcomment,
+                        "check empty key comment",
+                    )
+
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
+
     def testHeaderFromCards(self):
         """
         test generating a header from cards, writing it out and getting

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -519,7 +519,7 @@ class TestReadWrite(unittest.TestCase):
                     self.assertEqual(
                         rec['name'],
                         None,
-                        'checking comment is called COMMENT',
+                        'checking name is None',
                     )
                     comment = rec['comment']
                     rcomment = rrec['comment']
@@ -531,6 +531,64 @@ class TestReadWrite(unittest.TestCase):
                         rcomment,
                         "check empty key comment",
                     )
+
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
+    def testBlankKeyCommentsFromCards(self):
+        """
+        test a few different comments
+        """
+
+        fname=tempfile.mktemp(prefix='fitsio-HeaderComments-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                records = [
+                    '                                                                                ',
+                    '         --- testing comment ---                                                ',
+                    "COMMENT testing                                                                 ",
+                ]
+                header = fitsio.FITSHDR(records)
+
+                fits.write(None, header=header)
+
+                rh = fits[0].read_header()
+
+                rrecords = rh.records()
+
+                self.assertEqual(
+                    rrecords[6]['name'],
+                    None,
+                    'checking name is None',
+                )
+                self.assertEqual(
+                    rrecords[6]['comment'],
+                    '',
+                    "check empty key comment",
+                )
+                self.assertEqual(
+                    rrecords[7]['name'],
+                    None,
+                    'checking name is None',
+                )
+                self.assertEqual(
+                    rrecords[7]['comment'],
+                    '--- testing comment ---',
+                    "check empty key comment",
+                )
+
+                self.assertEqual(
+                    rrecords[5]['name'],
+                    'COMMENT',
+                    'checking name is COMMENT',
+                )
+                self.assertEqual(
+                    rrecords[5]['comment'],
+                    'testing',
+                    "check comment",
+                )
+
 
         finally:
             if os.path.exists(fname):


### PR DESCRIPTION
closes #249 

the current version writes them correctly when adding cards as a dict

todo
- [x] add tests
- [x] add writing from cards
- [x] they currently get read back as empty comments, yet another casualty of the header reading optimizations
