### PR TITLE
Scaling ignore feature 262

### DIFF
--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -41,9 +41,31 @@ class HDUBase(object):
 
         self._FITS = fits
         self._ext = ext
+        self._ignore_scaling = False
 
         self._update_info()
         self._filename = self._FITS.filename()
+
+    @property
+    def ignore_scaling(self):
+        """
+        :return: Flag to indicate whether scaling (BZERO/BSCALE) values should
+        be ignored.
+        """
+        return self._ignore_scaling
+
+    @ignore_scaling.setter
+    def ignore_scaling(self, ignore_scaling_flag):
+        """
+        Set the flag to ignore scaling.
+        """
+        old_val = self._ignore_scaling
+        self._ignore_scaling = ignore_scaling_flag
+
+        # Only endure the overhead of updating the info if the new value is
+        # actually different.
+        if old_val != self._ignore_scaling:
+            self._update_info()
 
     def get_extnum(self):
         """
@@ -344,7 +366,7 @@ class HDUBase(object):
         except IOError:
             raise RuntimeError("no such hdu")
 
-        self._info = self._FITS.get_hdu_info(self._ext+1)
+        self._info = self._FITS.get_hdu_info(self._ext+1, self._ignore_scaling)
 
     def _get_repr_list(self):
         """

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -62,7 +62,7 @@ class ImageHDU(HDUBase):
             return False
         else:
             return True
-
+            
     def is_compressed(self):
         """
         returns true of this extension is compressed
@@ -306,7 +306,8 @@ class ImageHDU(HDUBase):
 
         npy_dtype = self._get_image_numpy_dtype()
         array = numpy.zeros(arrdims, dtype=npy_dtype)
-        self._FITS.read_image_slice(self._ext+1, first, last, steps, array)
+        self._FITS.read_image_slice(self._ext+1, first, last, steps,
+                                    self._ignore_scaling, array)
         return array
 
     def _expand_if_needed(self, dims, write_dims, start, offset):

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -62,7 +62,7 @@ class ImageHDU(HDUBase):
             return False
         else:
             return True
-            
+
     def is_compressed(self):
         """
         returns true of this extension is compressed

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1134,6 +1134,40 @@ DATASUM =                      / checksum of the data records\n"""
                 os.remove(fname)
 
 
+    def testReadIgnoreScaling(self):
+        """
+        Test the flag to ignore scaling when reading an HDU.
+        """
+        fname = tempfile.mktemp(prefix='fitsio-ReadIgnoreScaling-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                dtype = 'i2'
+                data = numpy.arange(10 * 20, dtype=dtype).reshape(10, 20)
+                header={
+                    'DTYPE':dtype,
+                    'BITPIX': 16,
+                    'NBYTES':data.dtype.itemsize,
+                    'BZERO': 9.33,
+                    'BSCALE': 3.281
+                    }
+
+                fits.write_image(data, header=header)
+                hdu = fits[-1]
+                rdata = hdu.read()
+
+                self.assertEqual(rdata.dtype, numpy.float32, 'Wrong dtype.')
+
+                hdu.ignore_scaling = True
+                rdata = hdu.read()
+                self.assertEqual(rdata.dtype, dtype, 'Wrong dtype when ignoring.')
+
+                rh = fits[-1].read_header()
+                self.check_header(header, rh)
+        finally:
+            # Clean up.
+            if os.path.exists(fname):
+                os.remove(fname)
+
 
     def testWriteKeyDict(self):
         """


### PR DESCRIPTION
This is to add a feature to the `base.py` to use the `ignore_scaling` flag on an HDU before reading the data from it.  Default value is `False` to preserve existing functionality.

This is useful when the `BZERO` AND `BSCALE` values are set to scale the pixels, but the user/caller wants to cut from the original pixels.

The API ice used like this:
```python
import fitsio

fits = fitsio.FITS('file.fits', 'r'). # File with BZERO=23.5 and BSCALE=0.4 for example.
hdu_1 = fits[1]
cut_1 = hdu_1[20:100,:]. # Will return scaled slice (BZERO+DAT*BSCALE)

hdu_1.ignore_scaling = True
cut_2 = hdu_1[20:100,:]. # Will return unscaled slice (BZERO=0.0, BSCALE=1.0)
```

**Note**:
In order for tests to pass, this relies on the `test.py` fixes from PR #271.