### PR TITLE
Add fix to allow striding.

### DIFF
--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -25,6 +25,7 @@ from functools import reduce
 
 import numpy
 
+from math import floor
 from .base import HDUBase, IMAGE_HDU
 from ..util import IS_PY3, array_to_native
 
@@ -293,7 +294,7 @@ class ImageHDU(HDUBase):
             first.append(start)
             last.append(stop)
             steps.append(step)
-            arrdims.append(stop-start+1)
+            arrdims.append(int(floor((stop - start) / step)) + 1)
 
             dim += 1
 

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1041,6 +1041,27 @@ DATASUM =                      / checksum of the data records\n"""
             if os.path.exists(fname):
                 os.remove(fname)
 
+    def testImageSliceStriding(self):
+        """
+        test reading an image slice
+        """
+        fname=tempfile.mktemp(prefix='fitsio-ImageSliceStriding-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                # note mixing up byte orders a bit
+                for dtype in ['u1','i1','u2','i2','<u4','i4','i8','>f4','f8']:
+                    data = numpy.arange(16*20,dtype=dtype).reshape(16,20)
+                    header={'DTYPE':dtype,'NBYTES':data.dtype.itemsize}
+                    fits.write_image(data, header=header)
+
+                    rdata = fits[-1][4:16:4, 2:20:2]
+                    expected_data = data[4:16:4, 2:20:2]
+                    self.assertEqual(rdata.shape, expected_data.shape, "Shapes differ with dtype %s" % dtype)
+                    self.compare_array(expected_data, rdata, "images with dtype %s" % dtype)
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
     def testPLIOTileCompressedWriteRead(self):
         """
         test writing and readin PLIO compressed image


### PR DESCRIPTION
Fixes #264 

Specifying a step in an image slice should shrink the dimension of the output.

```python
import fitsio
import numpy

fits = fitsio.FITS('file.fits', 'rw')
data = numpy.arange(10000).reshape(100,100)
fits.write(data)
hdu = fits[-1]
cut = hdu[:,10:50:8]. # Starting at pixel 10, step every 8th pixel until the 50th one along the second axis.
cut.shape
```

Will output:
```python
(100, 5)
```

Rather than:
```python
(100, 40)
```

This is useful when slicing a large portion of a larger image but want to skip some pixels to save space.