### PR TITLE
Support flipping along the axis when slicing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ version 1.1.0
 New Features
 
     - Updated to cfitsio version 3.470 (#261)
+    - Add ability to stride (step value) when slicing
+    - Add feature to flip along axis when slicing
 
 Deprecations
 
@@ -19,6 +21,7 @@ Bug Fixes
 
     - fixed bug getting `None` keywords
     - fixed bug writing 64 bit images (#256, #257)
+    - fixed HISTORY card value not being read
 
 version 1.0.4
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ data = fits[1][10:20]
 data = fits[1][10:20:2]
 data = fits[1][[1,5,18]]
 
+# Using EXTNAME and EXTVER values
+data = fits['SCI',2][10:20]
+
+# Slicing with reverse (flipped) striding
+data = fits[1][40:25]
+data = fits[1][40:25:-5]
+
 # all rows of column 'x'
 data = fits[1]['x'][:]
 

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -25,6 +25,7 @@ from functools import reduce
 
 import numpy
 
+from math import floor
 from .base import HDUBase, IMAGE_HDU
 from ..util import IS_PY3, array_to_native
 
@@ -284,16 +285,17 @@ class ImageHDU(HDUBase):
             # move to 1-offset
             start = start + 1
 
-            if stop < start:
-                raise ValueError("python slices but include at least one "
-                                 "element, got %s" % slc)
             if stop > dims[dim]:
                 stop = dims[dim]
+            if stop < start:
+                dimension = int(floor((stop - start) / (step * -1))) + 1
+            else:
+                dimension = int(floor((stop - start) / step)) + 1
 
             first.append(start)
             last.append(stop)
             steps.append(step)
-            arrdims.append(stop-start+1)
+            arrdims.append(dimension)
 
             dim += 1
 

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -288,6 +288,12 @@ class ImageHDU(HDUBase):
             if stop > dims[dim]:
                 stop = dims[dim]
             if stop < start:
+                # A little black magic here.  The stop is offset by 2 to accommodate
+                # the 1-offset of CFITSIO, and to move past the end pixel to get the complete
+                # set after it is flipped along the axis.  Maybe there is a clearer way to
+                # accomplish what this offset is glossing over.
+                # @at88mph 2019.10.10
+                stop = stop + 2
                 dimension = int(floor((stop - start) / (step * -1))) + 1
             else:
                 dimension = int(floor((stop - start) / step)) + 1

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -256,6 +256,7 @@ class ImageHDU(HDUBase):
         first = []
         last = []
         steps = []
+        npy_dtype = self._get_image_numpy_dtype()
 
         # check the args and reverse dimensions since
         # fits is backwards from numpy
@@ -277,10 +278,8 @@ class ImageHDU(HDUBase):
                     step = -1
 
             # Sanity checks for proper syntax.
-            if step < 0 and start < stop:
-                raise ValueError("slice steps must be >= 1 when start < stop")
-            elif step > 0 and stop < start:
-                raise ValueError("slice steps must be < 0 when stop < start")
+            if (step > 0 and stop < start) or (step < 0 and start < stop):
+                return numpy.empty(0, dtype=npy_dtype)
             if start < 0:
                 start = dims[dim] + start
                 if start < 0:
@@ -320,7 +319,6 @@ class ImageHDU(HDUBase):
         last = numpy.array(last, dtype='i8')
         steps = numpy.array(steps, dtype='i8')
 
-        npy_dtype = self._get_image_numpy_dtype()
         array = numpy.zeros(arrdims, dtype=npy_dtype)
         self._FITS.read_image_slice(self._ext+1, first, last, steps,
                                     self._ignore_scaling, array)

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1071,17 +1071,18 @@ DATASUM =                      / checksum of the data records\n"""
                         "Data are not the same (Expected shape: {}, actual shape: {}.".format(
                             expected_data.shape, rdata.shape))
 
-                try:
-                    hdu[:,90:60:4]  # Positive step integer does not follow numpy syntax.
-                    raise AssertionError('Should raise ValueError.')
-                except ValueError as value_error:
-                    self.assertEqual('{}'.format(str(value_error)), 'slice steps must be < 0 when stop < start')
+                
+                rdata = hdu[:,90:60:4]  # Positive step integer with start > stop will return an empty array
+                expected_data = numpy.empty(0, dtype=dtype)
+                numpy.testing.assert_array_equal(expected_data, rdata,
+                        "Data are not the same (Expected shape: {}, actual shape: {}.".format(
+                            expected_data.shape, rdata.shape))
 
-                try:
-                    hdu[:,60:90:-4]
-                    raise AssertionError('Should raise ValueError.')
-                except ValueError as value_error:
-                    self.assertEqual('{}'.format(str(value_error)), 'slice steps must be >= 1 when start < stop')
+                rdata = hdu[:,60:90:-4]  # Negative step integer with start < stop will return an empty array.
+                expected_data = numpy.empty(0, dtype=dtype)
+                numpy.testing.assert_array_equal(expected_data, rdata,
+                        "Data are not the same (Expected shape: {}, actual shape: {}.".format(
+                            expected_data.shape, rdata.shape))
         finally:
             if os.path.exists(fname):
                 os.remove(fname)

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1062,7 +1062,7 @@ DATASUM =                      / checksum of the data records\n"""
                         "Data are not the same (Expected shape: {}, actual shape: {}.".format(
                             expected_data.shape, rdata.shape))
 
-                rdata = hdu[:,130:70:6]
+                rdata = hdu[:,130:70:-6]
 
                 # Expanded by two to emulate adding one to the start value, and adding one to the calculated dimension.
                 expected_data = data[:,130:70:-6]
@@ -1070,6 +1070,18 @@ DATASUM =                      / checksum of the data records\n"""
                 numpy.testing.assert_array_equal(expected_data, rdata,
                         "Data are not the same (Expected shape: {}, actual shape: {}.".format(
                             expected_data.shape, rdata.shape))
+
+                try:
+                    hdu[:,90:60:4]  # Positive step integer does not follow numpy syntax.
+                    raise AssertionError('Should raise ValueError.')
+                except ValueError as value_error:
+                    self.assertEqual('{}'.format(str(value_error)), 'slice steps must be < 0 when stop < start')
+
+                try:
+                    hdu[:,60:90:-4]
+                    raise AssertionError('Should raise ValueError.')
+                except ValueError as value_error:
+                    self.assertEqual('{}'.format(str(value_error)), 'slice steps must be >= 1 when start < stop')
         finally:
             if os.path.exists(fname):
                 os.remove(fname)

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1056,7 +1056,7 @@ DATASUM =                      / checksum of the data records\n"""
                 rdata = hdu[:,130:70]
 
                 # Expanded by two to emulate adding one to the start value, and adding one to the calculated dimension.
-                expected_data = data[:,130:68:-1]
+                expected_data = data[:,130:70:-1]
 
                 numpy.testing.assert_array_equal(expected_data, rdata,
                         "Data are not the same (Expected shape: {}, actual shape: {}.".format(
@@ -1065,12 +1065,11 @@ DATASUM =                      / checksum of the data records\n"""
                 rdata = hdu[:,130:70:6]
 
                 # Expanded by two to emulate adding one to the start value, and adding one to the calculated dimension.
-                expected_data = data[:,130:68:-6]
+                expected_data = data[:,130:70:-6]
 
                 numpy.testing.assert_array_equal(expected_data, rdata,
                         "Data are not the same (Expected shape: {}, actual shape: {}.".format(
                             expected_data.shape, rdata.shape))
-
         finally:
             if os.path.exists(fname):
                 os.remove(fname)

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1041,6 +1041,40 @@ DATASUM =                      / checksum of the data records\n"""
             if os.path.exists(fname):
                 os.remove(fname)
 
+    def testReadFlipAxisSlice(self):
+        """
+        Test reading a slice when the slice's start is less than the slice's stop.
+        """
+
+        fname=tempfile.mktemp(prefix='fitsio-ReadFlipAxisSlice-',suffix='.fits')
+        try:
+            with fitsio.FITS(fname, 'rw', clobber=True) as fits:
+                dtype = numpy.int16
+                data = numpy.arange(100 * 200, dtype=dtype).reshape(100, 200)
+                fits.write_image(data)
+                hdu = fits[-1]
+                rdata = hdu[:,130:70]
+
+                # Expanded by two to emulate adding one to the start value, and adding one to the calculated dimension.
+                expected_data = data[:,130:68:-1]
+
+                numpy.testing.assert_array_equal(expected_data, rdata,
+                        "Data are not the same (Expected shape: {}, actual shape: {}.".format(
+                            expected_data.shape, rdata.shape))
+
+                rdata = hdu[:,130:70:6]
+
+                # Expanded by two to emulate adding one to the start value, and adding one to the calculated dimension.
+                expected_data = data[:,130:68:-6]
+
+                numpy.testing.assert_array_equal(expected_data, rdata,
+                        "Data are not the same (Expected shape: {}, actual shape: {}.".format(
+                            expected_data.shape, rdata.shape))
+
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
     def testPLIOTileCompressedWriteRead(self):
         """
         test writing and readin PLIO compressed image


### PR DESCRIPTION
Fixes #268 

This will likely conflict with PR #274 .

This feature enables a caller to slice along an axis in reverse.

```python
import fitsio
import numpy

fits = fitsio.FITS('outputfile.fits', 'rw', clobber=True)
dtype = numpy.int16
data = numpy.arange(100 * 200, dtype=dtype).reshape(100, 200)
fits.write_image(data)
hdu = fits[-1]
rdata = hdu[:,130:70]
rdata.shape # Will be (100, 60)

ndatacut = data[:,130:70:-1]. # Equivalent to numpy directly.
ndatacut.shape # Will be (100, 60)
```
