### PR TITLE
Fix bug when reading slice with step, but no start/stop

### DIFF
--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -1452,7 +1452,7 @@ class TableHDU(HDUBase):
 
         tstart = self._fix_range(start)
         tstop = self._fix_range(stop)
-        if tstart == 0 and tstop == nrows:
+        if tstart == 0 and tstop == nrows and step is None:
             # this is faster: if all fields are also requested, then a
             # single fread will be done
             return None

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -2174,6 +2174,12 @@ DATASUM =                      / checksum of the data records\n"""
                 for f in self.data.dtype.names:
                     d = fits[1][f][1:3]
                     self.compare_array(self.data[f][1:3], d, "test %s row slice" % f)
+                for f in self.data.dtype.names:
+                    d = fits[1][f][1:4:2]
+                    self.compare_array(self.data[f][1:4:2], d, "test %s row slice with step" % f)
+                for f in self.data.dtype.names:
+                    d = fits[1][f][::2]
+                    self.compare_array(self.data[f][::2], d, "test %s row slice with only setp" % f)
 
                 # now list of columns
                 cols=['u2scalar','f4vec','Sarr']


### PR DESCRIPTION
I ran into this bug when adding a feature to TreeCorr that would read only every nth row in the input catalog.  It worked when start or stop were specified, but not when reading from the whole range.