### PR TITLE
Fix table.py for Python 3.8

### DIFF
--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -231,7 +231,7 @@ class TableHDU(HDUBase):
                                  "write_column to write to a single column, "
                                  "or instead write to an image hdu")
 
-            if data.shape is ():
+            if data.shape == ():
                 raise ValueError("cannot write data with shape ()")
 
             isrec = True


### PR DESCRIPTION
Fixes:

fitsio/hdu/table.py:234: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if data.shape is ():
fitsio/hdu/table.py:234: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if data.shape is ():

Error found in https://github.com/Homebrew/homebrew-core/pull/47326