### PR TITLE
Fix comment order in returned header object

### DIFF
--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -565,8 +565,8 @@ class TestReadWrite(unittest.TestCase):
 
                 rrecords = rh.records()
                 from pprint import pprint
-                print()
-                pprint(rrecords)
+                # print()
+                # pprint(rrecords)
 
                 self.assertEqual(
                     rrecords[6]['name'],
@@ -601,12 +601,12 @@ class TestReadWrite(unittest.TestCase):
 
 
                 self.assertEqual(
-                    rrecords[5]['name'],
+                    rrecords[9]['name'],
                     'COMMENT',
                     'checking name is COMMENT',
                 )
                 self.assertEqual(
-                    rrecords[5]['comment'],
+                    rrecords[9]['comment'],
                     'testing',
                     "check comment",
                 )


### PR DESCRIPTION
closes #277 

don't use reading by key name for comments and history
    
This fixes a bug where comments and history were returned in the wrong
order.  They share the same name, so reading by name is the wrong thing
in this case.