### PR TITLE
Store card string

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4329,6 +4329,8 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
         }
 
         dict = PyDict_New();
+        add_string_to_dict(dict, "raw_card_string", card);
+
         if (is_blank_key) {
             add_none_to_dict(dict,"name");
             add_string_to_dict(dict,"value","");

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4329,7 +4329,7 @@ PyFITSObject_read_header(struct PyFITSObject* self, PyObject* args) {
         }
 
         dict = PyDict_New();
-        add_string_to_dict(dict, "raw_card_string", card);
+        add_string_to_dict(dict, "card_string", card);
 
         if (is_blank_key) {
             add_none_to_dict(dict,"name");

--- a/fitsio/header.py
+++ b/fitsio/header.py
@@ -441,10 +441,11 @@ class FITSHDR(object):
     def __repr__(self):
         rep = ['']
         for r in self._record_list:
-            if 'card_string' not in r:
-                card = self._record2card(r)
-            else:
-                card = r['card_string']
+            card = self._record2card(r)
+            # if 'card_string' not in r:
+            #     card = self._record2card(r)
+            # else:
+            #     card = r['card_string']
 
             rep.append(card)
         return '\n'.join(rep)


### PR DESCRIPTION
closes #293 

Store `card_string` in the header entries read from disk.

These can contain incomplete data, so for repr we use a fake card that can be longer