### PR TITLE
Add support for automatically building wheels on Linux and Mac

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,26 +17,16 @@ jobs:
       matrix:
         os: 
           - ubuntu-20.04
-#           - windows-2019
           - macos-10.15
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
-          fetch-depth: 0
-      
-      - uses: ilammy/msvc-dev-cmd@v1
-        if: runner.os == 'Windows'
-        
       - uses: joerick/cibuildwheel@v1.10.0
         env:
           CIBW_BUILD: "cp3?-*"
-          CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686"
-#           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+#           CIBW_SKIP: "*-manylinux_i686"
           CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2-devel
           DISTUTILS_USE_SDK: 1
           MSSdk: 1
-
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -46,15 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
-          fetch-depth: 0
-
       - uses: actions/setup-python@v2
         name: Install Python
         with:
           python-version: "3.9"
-
       - name: Build sdist
         run: |
           python -m pip install -U pip build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,74 @@
+name: Wheels
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - master
+      - wheels
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+        
+      - uses: joerick/cibuildwheel@v1.10.0
+        env:
+          CIBW_BUILD: "cp3?-*"
+          CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          DISTUTILS_USE_SDK: 1
+          MSSdk: 1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: "3.9"
+
+      - name: Build sdist
+        run: |
+          python -m pip install -U pip build
+          python -m build --sdist .
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+#   upload_pypi:
+#     needs: [build_wheels, build_sdist]
+#     runs-on: ubuntu-latest
+#     if: github.event_name == 'release' && github.event.action == 'published'
+#     steps:
+#       - uses: actions/download-artifact@v2
+#         with:
+#           name: artifact
+#           path: dist
+
+#       - uses: pypa/gh-action-pypi-publish@master
+#         with:
+#           user: __token__
+#           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+#           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2-devel
           DISTUTILS_USE_SDK: 1
           MSSdk: 1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2
+          CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2-libs
           DISTUTILS_USE_SDK: 1
           MSSdk: 1
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,10 +3,12 @@ on:
   release:
     types:
       - published
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master
-      - wheels
 
 jobs:
   build_wheels:
@@ -23,10 +25,7 @@ jobs:
       - uses: joerick/cibuildwheel@v1.10.0
         env:
           CIBW_BUILD: "cp3?-*"
-#           CIBW_SKIP: "*-manylinux_i686"
           CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2-devel
-          DISTUTILS_USE_SDK: 1
-          MSSdk: 1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -48,6 +47,7 @@ jobs:
         with:
           path: dist/*.tar.gz
 
+#   # Uncomment this section to automatically upload release to PyPI
 #   upload_pypi:
 #     needs: [build_wheels, build_sdist]
 #     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
 #           name: artifact
 #           path: dist
 
-#       - uses: pypa/gh-action-pypi-publish@master
+#       - uses: pypa/gh-action-pypi-publish@v1.4.2
 #         with:
 #           user: __token__
 #           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,8 +13,12 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: 
+          - ubuntu-20.04
+#           - windows-2019
+          - macos-10.15
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2-libs
+          CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2-devel
           DISTUTILS_USE_SDK: 1
           MSSdk: 1
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,6 +29,7 @@ jobs:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp35-* *-win32 *-manylinux_i686"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BEFORE_BUILD_LINUX: yum install -y bzip2
           DISTUTILS_USE_SDK: 1
           MSSdk: 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "numpy==1.13.3; python_version<'3.5'",
+    "oldest-supported-numpy; python_version>='3.5'",
+]
+
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds a GitHub actions workflow that uses [cibuildwheel](https://github.com/joerick/cibuildwheel) to automatically build binary wheels for the standard Linux and Mac platforms. These wheels could be uploaded to PyPI manually or uploaded automatically (this is what I do with most of my projects). This would help with issues like #298 (because it packages all of the dependencies) and generally speed up pip-based dependency workflows, but some users might prefer to tune their cfitsio, and it adds some developer overhead, so you should definitely feel free to veto/ignore/etc.!

Also, I'll be happy to squash/rebase to clean up the history if this is something that you're interested in merging.