### PR TITLE
append() not forwarding arguments

### DIFF
--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -550,7 +550,7 @@ class TableHDU(HDUBase):
                 DeprecationWarning, stacklevel=2)
 
         firstrow = self._info['nrows']
-        self.write(data, firstrow=firstrow, columns=None, names=None)
+        self.write(data, firstrow=firstrow, columns=columns, names=names)
 
     def delete_rows(self, rows):
         """

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -2405,6 +2405,22 @@ DATASUM =                      / checksum of the data records\n"""
                 h = fits[1].read_header()
                 self.compare_headerlist_header(self.keys, h)
 
+                # append with list of arrays and names
+                names = self.data.dtype.names
+                data3 = [numpy.array(self.data[name]) for name in names]
+                fits[1].append(data3, names=names)
+
+                d = fits[1].read()
+                self.assertEqual(d.size, self.data.size*3)
+                self.compare_rec(self.data, d[2*self.data.size:], "Comparing appended data")
+
+                # append with list of arrays and columns
+                fits[1].append(data3, columns=names)
+
+                d = fits[1].read()
+                self.assertEqual(d.size, self.data.size*4)
+                self.compare_rec(self.data, d[3*self.data.size:], "Comparing appended data")
+
         finally:
             if os.path.exists(fname):
                 os.remove(fname)


### PR DESCRIPTION
The `append()` method did not forward the `columns` and `names` arguments to `write()`.