### PR TITLE
testCompressPreserveZeros: do not test with the hcompress algorithm

### DIFF
--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -1351,7 +1351,8 @@ DATASUM =                      / checksum of the data records\n"""
             (1, 3),
             (2, 9),
         ]
-        for compress in ['gzip', 'gzip_2', 'rice', 'hcompress']:
+        # Do not test hcompress as it doesn't support SUBTRACTIVE_DITHER_2
+        for compress in ['gzip', 'gzip_2', 'rice']:
             fname=tempfile.mktemp(prefix='fitsio-ImageWrite-',suffix='.fits.fz')
             try:
                 with fitsio.FITS(fname,'rw',clobber=True) as fits:


### PR DESCRIPTION
Starting with version 4.1.0, CFITSIO removed the SUBTRACTIVE_DITHER_2
option has been removed when using the HCOMPRESS algorithm. Drop the
corresponding test on the fitsio side so that the testsuite still
passes.