### PR TITLE
ENH: support for ranges in where()

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -4542,9 +4542,8 @@ PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
     int hdutype=0;
     char* expression=NULL;
 
-    LONGLONG nrows=0;
-
-    long firstrow=1;
+    long firstrow;
+    long nrows;
     long ngood=0;
     char* row_status=NULL;
 
@@ -4557,16 +4556,18 @@ PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
     long i=0;
 
 
-    if (!PyArg_ParseTuple(args, (char*)"is", &hdunum, &expression)) {
+    if (!PyArg_ParseTuple(args, (char*)"isll", &hdunum, &expression,
+                          &firstrow, &nrows)) {
+        return NULL;
+    }
+
+    if (firstrow < 1 || nrows < 1) {
+        PyErr_SetString(PyExc_ValueError,
+                        "firstrow and nrows must be positive integers");
         return NULL;
     }
 
     if (fits_movabs_hdu(self->fits, hdunum, &hdutype, &status)) {
-        set_ioerr_string_from_status(status);
-        return NULL;
-    }
-
-    if (fits_get_num_rowsll(self->fits, &nrows, &status)) {
         set_ioerr_string_from_status(status);
         return NULL;
     }
@@ -4577,7 +4578,7 @@ PyFITSObject_where(struct PyFITSObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (fits_find_rows(self->fits, expression, firstrow, (long) nrows, &ngood, row_status, &status)) {
+    if (fits_find_rows(self->fits, expression, firstrow, nrows, &ngood, row_status, &status)) {
         set_ioerr_string_from_status(status);
         goto where_function_cleanup;
     }

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -152,7 +152,7 @@ class TableHDU(HDUBase):
         else:
             return False
 
-    def where(self, expression):
+    def where(self, expression, firstrow=None, lastrow=None):
         """
         Return the indices where the expression evaluates to true.
 
@@ -161,8 +161,21 @@ class TableHDU(HDUBase):
         expression: string
             A fits row selection expression.  E.g.
             "x > 3 && y < 5"
+        firstrow, lastrow : int
+            Range of rows for evaluation.
         """
-        return self._FITS.where(self._ext+1, expression)
+        if firstrow is None:
+            firstrow = 0
+        elif firstrow < 0:
+            raise ValueError('firstrow cannot be negative')
+        if lastrow is None:
+            lastrow = self._info['nrows']
+        elif lastrow < firstrow:
+            raise ValueError('lastrow cannot be less than firstrow')
+        elif lastrow > self._info['nrows']:
+            raise ValueError('lastrow cannot be greater than nrows')
+        nrows = lastrow - firstrow
+        return self._FITS.where(self._ext+1, expression, firstrow+1, nrows)
 
     def write(self, data, firstrow=0, columns=None, names=None, slow=False,
               **keys):

--- a/fitsio/test.py
+++ b/fitsio/test.py
@@ -2239,6 +2239,37 @@ DATASUM =                      / checksum of the data records\n"""
             if os.path.exists(fname):
                 os.remove(fname)
 
+    def testTableWhere(self):
+        """
+        Use the where method to get indices for a row filter expression
+        """
+
+        fname=tempfile.mktemp(prefix='fitsio-TableWhere-',suffix='.fits')
+        try:
+
+            with fitsio.FITS(fname,'rw',clobber=True) as fits:
+                fits.write_table(self.data2)
+
+            #
+            # get all indices
+            #
+            with fitsio.FITS(fname) as fits:
+                a = fits[1].where('x > 3 && y < 8')
+            b = numpy.where((self.data2['x'] > 3) & (self.data2['y'] < 8))[0]
+            numpy.testing.assert_array_equal(a, b)
+
+            #
+            # get slice of indices
+            #
+            with fitsio.FITS(fname) as fits:
+                a = fits[1].where('x > 3 && y < 8', 2, 8)
+            b = numpy.where((self.data2['x'][2:8] > 3) & (self.data2['y'][2:8] < 8))[0]
+            numpy.testing.assert_array_equal(a, b)
+
+        finally:
+            if os.path.exists(fname):
+                os.remove(fname)
+
     def testTableResize(self):
         """
         Use the resize method to change the size of a table


### PR DESCRIPTION
Add `firstrow` and `lastrow` parameters to the `where()` method of table HDUs to get indices in slices of rows:

```py
fits[1].where('x > 2 && y < 8', 4, 12)  # firstrow, lastrow
```

Closes #362.