### PR TITLE
Return table data in order requested by user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@ version 1.1.9
 Changes
 
     - Row subsets of table data are returned in the order sent by the user
-      rather than sorted and unique.  E.g. rows = [3, 1] will return
-      data corresponding to that order of rows.
+      rather than sorted and unique.  E.g. rows = [2, 2, 1] will return
+      data corresponding to that order of rows, including duplicates.
     - Removed deprecated `pkg_resources` from tests (M. Becker).
     - converted tests to use pytest
     - Improved doc strings (N. Tessore)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ version 1.1.9
 
 Changes
 
+    - Row subsets of table data are returned in the order sent by the user
+      rather than sorted and unique.  E.g. rows = [3, 1] will return
+      data corresponding to that order of rows.
     - Removed deprecated `pkg_resources` from tests (M. Becker).
     - converted tests to use pytest
     - Improved doc strings (N. Tessore)

--- a/README.md
+++ b/README.md
@@ -71,11 +71,6 @@ fitsio.write(filename, data)
 
 fitsio.write(filename, image)
 
-# NOTE when reading row subsets, the data must still be read from disk.
-# This is most efficient if the data are read in the order they appear in
-# the file.  For this reason, the rows are always returned in row-sorted
-# order.
-
 #
 # the FITS class gives the you the ability to explore the data, and gives
 # more control
@@ -178,10 +173,14 @@ data = fits[1]['x'][:]
 # each column
 data = fits[1]['x','y'][:]
 
-# General column and row subsets.  As noted above, the data are returned
-# in row sorted order for efficiency reasons.
+# General column and row subsets.
 columns=['index','x','y']
-rows=[1,5]
+rows = [1, 5]
+data = fits[1][columns][rows]
+
+# data are returned in the order requested by the user
+# and duplicates are preserved
+rows = [2, 2, 5]
 data = fits[1][columns][rows]
 
 # iterate over rows in a table hdu

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -3093,7 +3093,12 @@ static int read_ascii_column_all(fitsfile* fits, int colnum, PyObject* array, in
 
 }
 static int read_ascii_column_byrow(
-        fitsfile* fits, int colnum, PyObject* array, PyObject* rowsObj, int* status) {
+        fitsfile* fits, int colnum, PyObject* array,
+        PyObject* rowsObj,
+        PyObject* sortindObj,
+        int* status
+)
+{
 
     int npy_dtype=0;
     int fits_dtype=0;
@@ -3101,6 +3106,7 @@ static int read_ascii_column_byrow(
     npy_intp nelem=0;
     LONGLONG firstelem=1;
     LONGLONG rownum=0;
+    npy_int64 si=0;
     npy_intp nrows=-1;
 
     int* anynul=NULL;
@@ -3129,16 +3135,17 @@ static int read_ascii_column_byrow(
         }
     }
 
-    data = PyArray_GETPTR1(array, i);
     for (i=0; i<nrows; i++) {
         if (dorows) {
-            rownum = (LONGLONG) (1 + *(npy_int64*) PyArray_GETPTR1(rowsObj, i));
+            si = *(npy_int64*) PyArray_GETPTR1(sortindObj, i);
+            rownum = (LONGLONG)( *(npy_int64*) PyArray_GETPTR1(rowsObj, si) );
+            rownum += 1;
         } else {
             rownum = (LONGLONG) (1+i);
         }
         // assuming 1-D
-        data = PyArray_GETPTR1(array, i);
-        if (fits_dtype==TSTRING) {
+        data = PyArray_GETPTR1(array, si);
+        if (fits_dtype == TSTRING) {
             cdata = (char* ) data;
             if (fits_read_col_str(fits,colnum,rownum,firstelem,1,nulstr,&cdata,anynul,status) > 0) {
                 return 1;
@@ -3154,11 +3161,19 @@ static int read_ascii_column_byrow(
 }
 
 
-static int read_ascii_column(fitsfile* fits, int colnum, PyObject* array, PyObject* rowsObj, int* status) {
+static int read_ascii_column(
+    fitsfile* fits, int colnum, PyObject* array,
+    PyObject* rowsObj,
+    PyObject* sortindObj,
+    int* status
+)
+{
 
     int ret=0;
     if (rowsObj != Py_None || !PyArray_ISCONTIGUOUS(array)) {
-        ret = read_ascii_column_byrow(fits, colnum, array, rowsObj, status);
+        ret = read_ascii_column_byrow(
+            fits, colnum, array, rowsObj, sortindObj, status
+        );
     } else {
         ret = read_ascii_column_all(fits, colnum, array, status);
     }
@@ -3177,14 +3192,15 @@ static int read_binary_column(
         int colnum,
         npy_intp nrows,
         npy_int64* rows,
-        void* data,
+        npy_int64* sortind,
+        void* vdata,
         npy_intp stride,
         int* status) {
 
     FITSfile* hdu=NULL;
     tcolumn* colptr=NULL;
     LONGLONG file_pos=0, irow=0;
-    npy_int64 row=0;
+    npy_int64 row=0, si=0;
 
     LONGLONG repeat=0;
     LONGLONG width=0;
@@ -3193,7 +3209,9 @@ static int read_binary_column(
 
     // use char for pointer arith.  It's actually ok to use void as char but
     // this is just in case.
-    char* ptr=NULL;
+    char *data=NULL, *ptr=NULL;
+
+    data = (char *) vdata;
 
     // using struct defs here, could cause problems
     hdu = fits->Fptr;
@@ -3204,19 +3222,21 @@ static int read_binary_column(
 
     rows_sent = nrows == hdu->numrows ? 0 : 1;
 
-    ptr = (char*) data;
     for (irow=0; irow<nrows; irow++) {
         if (rows_sent) {
-            row = rows[irow];
+            si = sortind[irow];
+            row = rows[si];
         } else {
             row = irow;
         }
+
+        ptr = data + si * stride;
+
         file_pos = hdu->datastart + row*hdu->rowlength + colptr->tbcol;
         ffmbyt(fits, file_pos, REPORT_EOF, status);
         if (ffgbytoff(fits, width, repeat, 0, (void*)ptr, status)) {
             return 1;
         }
-        ptr += stride;
     }
 
     return 0;
@@ -3240,8 +3260,10 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
     PyObject* array=NULL;
 
     PyObject* rowsObj;
+    PyObject* sortindObj;
 
-    if (!PyArg_ParseTuple(args, (char*)"iiOO", &hdunum, &colnum, &array, &rowsObj)) {
+    if (!PyArg_ParseTuple(args, (char*)"iiOOO",
+            &hdunum, &colnum, &array, &rowsObj, &sortindObj)) {
         return NULL;
     }
 
@@ -3267,22 +3289,23 @@ PyFITSObject_read_column(struct PyFITSObject* self, PyObject* args) {
 
 
     if (hdutype == ASCII_TBL) {
-        if (read_ascii_column(self->fits, colnum, array, rowsObj, &status)) {
+        if (read_ascii_column(self->fits, colnum, array, rowsObj, sortindObj, &status)) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
     } else {
         void* data=PyArray_DATA(array);
-        npy_intp nrows=0;
-        npy_int64* rows=NULL;
+        npy_intp nrows=0, nsortind=0;
+        npy_int64* rows=NULL, *sortind=NULL;
         npy_intp stride=PyArray_STRIDE(array,0);
         if (rowsObj == Py_None) {
             nrows = hdu->numrows;
         } else {
             rows = get_int64_from_array(rowsObj, &nrows);
+            sortind = get_int64_from_array(sortindObj, &nsortind);
         }
 
-        if (read_binary_column(self->fits, colnum, nrows, rows, data, stride, &status)) {
+        if (read_binary_column(self->fits, colnum, nrows, rows, sortind, data, stride, &status)) {
             set_ioerr_string_from_status(status);
             return NULL;
         }
@@ -3379,10 +3402,11 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
     int hdunum=0;
     int colnum=0;
     PyObject* rowsObj=NULL;
+    PyObject* sortindObj=NULL;
 
     int hdutype=0;
     int ncols=0;
-    const npy_int64* rows=NULL;
+    const npy_int64* rows=NULL, *sortind=NULL;
     LONGLONG nrows=0;
     int get_all_rows=0;
 
@@ -3396,11 +3420,12 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
     LONGLONG offset=0;
     LONGLONG i=0;
     LONGLONG row=0;
+    npy_int64 si = 0;
 
     PyObject* listObj=NULL;
     PyObject* tempObj=NULL;
 
-    if (!PyArg_ParseTuple(args, (char*)"iiO", &hdunum, &colnum, &rowsObj)) {
+    if (!PyArg_ParseTuple(args, (char*)"iiOO", &hdunum, &colnum, &rowsObj, &sortindObj)) {
         return NULL;
     }
 
@@ -3442,10 +3467,11 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
         fits_get_num_rowsll(self->fits, &nrows, &tstatus);
         get_all_rows=1;
     } else {
-        npy_intp tnrows=0;
+        npy_intp tnrows=0, nsortind=0;
         rows = (const npy_int64*) get_int64_from_array(rowsObj, &tnrows);
-        nrows=(LONGLONG) tnrows;
-        get_all_rows=0;
+        sortind = (const npy_int64*) get_int64_from_array(sortindObj, &nsortind);
+        nrows = (LONGLONG) tnrows;
+        get_all_rows = 0;
     }
 
     listObj = PyList_New(0);
@@ -3456,7 +3482,8 @@ PyFITSObject_read_var_column_as_list(struct PyFITSObject* self, PyObject* args) 
         if (get_all_rows) {
             row = i+1;
         } else {
-            row = (LONGLONG) (rows[i]+1);
+            si = sortind[i];
+            row = (LONGLONG) (rows[si]+1);
         }
 
         // repeat holds how many elements are in this row
@@ -3653,6 +3680,7 @@ static int read_columns_as_rec_byoffset(
         const npy_int64* field_offsets,   // offsets of corresponding fields within array
         npy_intp nrows,
         const npy_int64* rows,
+        const npy_int64* sortind,
         char* data,
         npy_intp recsize,
         int* status) {
@@ -3667,7 +3695,7 @@ static int read_columns_as_rec_byoffset(
 
     int get_all_rows=1;
     npy_intp irow=0;
-    npy_int64 row=0;
+    npy_int64 row=0, si=0;
 
     long groupsize=0; // number of bytes in column
     long ngroups=1; // number to read, one for row-by-row reading
@@ -3679,16 +3707,18 @@ static int read_columns_as_rec_byoffset(
 
     // using struct defs here, could cause problems
     hdu = fits->Fptr;
-    for (irow=0; irow<nrows; irow++) {
+    for (irow=0; irow < nrows; irow++) {
         if (get_all_rows) {
-            row=irow;
+            row = irow;
+            si = irow;
         } else {
-            row = rows[irow];
+            si = sortind[irow];
+            row = rows[si];
         }
         for (col=0; col < ncols; col++) {
 
             // point to this field in the array, allows for skipping
-            ptr = data + irow*recsize + field_offsets[col];
+            ptr = data + si*recsize + field_offsets[col];
 
             colnum = colnums[col];
             colptr = hdu->tableptr + (colnum-1);
@@ -3728,20 +3758,22 @@ PyFITSObject_read_columns_as_rec_byoffset(struct PyFITSObject* self, PyObject* a
 
     npy_intp ncols=0;
     npy_intp noffsets=0;
-    npy_intp nrows=0;
+    npy_intp nrows=0, nsortind=0;
     const npy_int64* colnums=NULL;
     const npy_int64* offsets=NULL;
-    const npy_int64* rows=NULL;
+    const npy_int64* rows=NULL, *sortind=NULL;
 
     PyObject* columnsObj=NULL;
     PyObject* offsetsObj=NULL;
     PyObject* rowsObj=NULL;
+    PyObject* sortindObj=NULL;
 
     PyObject* array=NULL;
     void* data=NULL;
     npy_intp recsize=0;
 
-    if (!PyArg_ParseTuple(args, (char*)"iOOOO", &hdunum, &columnsObj, &offsetsObj, &array, &rowsObj)) {
+    if (!PyArg_ParseTuple(args, (char*)"iOOOOO",
+            &hdunum, &columnsObj, &offsetsObj, &array, &rowsObj, &sortindObj)) {
         return NULL;
     }
 
@@ -3775,6 +3807,7 @@ PyFITSObject_read_columns_as_rec_byoffset(struct PyFITSObject* self, PyObject* a
 
     if (rowsObj != Py_None) {
         rows = (const npy_int64*) get_int64_from_array(rowsObj, &nrows);
+        sortind = (const npy_int64*) get_int64_from_array(sortindObj, &nsortind);
     } else {
         nrows = PyArray_SIZE(array);
     }
@@ -3786,6 +3819,7 @@ PyFITSObject_read_columns_as_rec_byoffset(struct PyFITSObject* self, PyObject* a
                 ncols, colnums, offsets,
                 nrows,
                 rows,
+                sortind,
                 (char*) data,
                 recsize,
                 &status) > 0) {

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -604,7 +604,7 @@ class TableHDU(HDUBase):
                 # rows must be 1-offset
                 rows = slice(rows.start+1, rows.stop+1)
         else:
-            rows = self._extract_rows(rows)
+            rows, sortind = self._extract_rows(rows)
             # rows must be 1-offset
             rows += 1
 
@@ -614,7 +614,7 @@ class TableHDU(HDUBase):
             if rows.size == 0:
                 return
 
-            self._FITS.delete_rows(self._ext+1, rows)
+            self._FITS.delete_rows(self._ext+1, rows, sortind)
 
         self._update_info()
 
@@ -1432,11 +1432,12 @@ class TableHDU(HDUBase):
             sortind = rows.argsort()
 
             maxrow = self._info['nrows']-1
-            firstrow = rows[sortind[0]]
-            lastrow = rows[sortind[-1]]
+            if rows.size > 0:
+                firstrow = rows[sortind[0]]
+                lastrow = rows[sortind[-1]]
 
-            if len(rows) > 0 and (firstrow < 0 or lastrow > maxrow):
-                raise ValueError("rows must be in [%d,%d]" % (0, maxrow))
+                if len(rows) > 0 and (firstrow < 0 or lastrow > maxrow):
+                    raise ValueError("rows must be in [%d,%d]" % (0, maxrow))
         else:
             sortind = None
 
@@ -2006,7 +2007,7 @@ class AsciiTableHDU(TableHDU):
                 columns, rows=rows, vstorage=vstorage,
                 upper=upper, lower=lower, trim_strings=trim_strings)
 
-        rows = self._extract_rows(rows)
+        rows, sortind = self._extract_rows(rows)
         if rows is None:
             nrows = self._info['nrows']
         else:

--- a/fitsio/tests/test_table.py
+++ b/fitsio/tests/test_table.py
@@ -71,40 +71,19 @@ def test_table_read_write():
                         adata['data'][f][:], d[f], "test column list %s" % f
                     )
 
-                rows = [1, 3]
-                d = fits[1].read(columns=cols, rows=rows)
-                for f in d.dtype.names:
-                    compare_array(
-                        adata['data'][f][rows], d[f],
-                        "test column list %s row subset" % f
-                    )
-
-
-def test_table_read_unsorted():
-
-    adata = make_data()
-    data = adata['data']
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        fname = os.path.join(tmpdir, 'test.fits')
-
-        with FITS(fname, 'rw') as fits:
-            fits.write_table(data)
-
-        # now test read_column
-        with FITS(fname) as fits:
-
-            rows = [3, 0, 1]
-            d = fits[1].read(rows=rows)
-            compare_rec(data[rows], d, "unsorted")
-
-            columns = ['f8scalar', 'i4vec', 'i2arr']
-            d = fits[1].read(
-                columns=columns,
-                rows=rows,
-            )
-            for col in columns:
-                compare_array(d[col], data[col][rows], 'unsorted col')
+                for rows in [[1, 3], [3, 1]]:
+                    d = fits[1].read(columns=cols, rows=rows)
+                    for col in d.dtype.names:
+                        compare_array(
+                            adata['data'][col][rows], d[col],
+                            "test column list %s row subset" % col
+                        )
+                    for col in cols:
+                        d = fits[1].read_column(col, rows=rows)
+                        compare_array(
+                            adata['data'][col][rows], d,
+                            "test column list %s row subset" % col
+                        )
 
 
 def test_table_column_index_scalar():
@@ -378,80 +357,80 @@ def test_variable_length_columns():
                 # now same with sub rows
                 #
 
-                # reading multiple columns
-                rows = [0, 2]
-                d = fits[1].read(rows=rows)
-                compare_rec_with_var(
-                    vardata, d, "read subrows test '%s'" % vstorage,
-                    rows=rows,
-                )
+                # reading multiple columns, sorted and unsorted
+                for rows in [[0, 2], [2, 0]]:
+                    d = fits[1].read(rows=rows)
+                    compare_rec_with_var(
+                        vardata, d, "read subrows test '%s'" % vstorage,
+                        rows=rows,
+                    )
 
-                d = fits[1].read(columns=cols, rows=rows)
-                compare_rec_with_var(
-                    vardata,
-                    d,
-                    "read subrows test subcols '%s'" % vstorage,
-                    rows=rows,
-                )
+                    d = fits[1].read(columns=cols, rows=rows)
+                    compare_rec_with_var(
+                        vardata,
+                        d,
+                        "read subrows test subcols '%s'" % vstorage,
+                        rows=rows,
+                    )
 
-                # one at a time
-                for f in vardata.dtype.names:
-                    d = fits[1].read_column(f, rows=rows)
-                    if util.is_object(vardata[f]):
-                        compare_object_array(
-                            vardata[f], d,
-                            "read subrows field '%s'" % f,
-                            rows=rows,
-                        )
+                    # one at a time
+                    for f in vardata.dtype.names:
+                        d = fits[1].read_column(f, rows=rows)
+                        if util.is_object(vardata[f]):
+                            compare_object_array(
+                                vardata[f], d,
+                                "read subrows field '%s'" % f,
+                                rows=rows,
+                            )
 
-                # same as above with slices
-                # reading multiple columns
-                d = fits[1][rows]
-                compare_rec_with_var(
-                    vardata, d, "read subrows slice test '%s'" % vstorage,
-                    rows=rows,
-                )
-                d = fits[1][2:4]
-                compare_rec_with_var(
-                    vardata,
-                    d,
-                    "read slice test '%s'" % vstorage,
-                    rows=[2, 3],
-                )
+                    # same as above with slices
+                    # reading multiple columns
+                    d = fits[1][rows]
+                    compare_rec_with_var(
+                        vardata, d, "read subrows slice test '%s'" % vstorage,
+                        rows=rows,
+                    )
+                    d = fits[1][2:4]
+                    compare_rec_with_var(
+                        vardata,
+                        d,
+                        "read slice test '%s'" % vstorage,
+                        rows=[2, 3],
+                    )
 
-                d = fits[1][cols][rows]
-                compare_rec_with_var(
-                    vardata,
-                    d,
-                    "read subcols subrows slice test '%s'" % vstorage,
-                    rows=rows,
-                )
+                    d = fits[1][cols][rows]
+                    compare_rec_with_var(
+                        vardata,
+                        d,
+                        "read subcols subrows slice test '%s'" % vstorage,
+                        rows=rows,
+                    )
 
-                d = fits[1][cols][2:4]
+                    d = fits[1][cols][2:4]
 
-                compare_rec_with_var(
-                    vardata,
-                    d,
-                    "read subcols slice test '%s'" % vstorage,
-                    rows=[2, 3],
-                )
+                    compare_rec_with_var(
+                        vardata,
+                        d,
+                        "read subcols slice test '%s'" % vstorage,
+                        rows=[2, 3],
+                    )
 
-                # one at a time
-                for f in vardata.dtype.names:
-                    d = fits[1][f][rows]
-                    if util.is_object(vardata[f]):
-                        compare_object_array(
-                            vardata[f], d,
-                            "read subrows field '%s'" % f,
-                            rows=rows,
-                        )
-                    d = fits[1][f][2:4]
-                    if util.is_object(vardata[f]):
-                        compare_object_array(
-                            vardata[f], d,
-                            "read slice field '%s'" % f,
-                            rows=[2, 3],
-                        )
+                    # one at a time
+                    for f in vardata.dtype.names:
+                        d = fits[1][f][rows]
+                        if util.is_object(vardata[f]):
+                            compare_object_array(
+                                vardata[f], d,
+                                "read subrows field '%s'" % f,
+                                rows=rows,
+                            )
+                        d = fits[1][f][2:4]
+                        if util.is_object(vardata[f]):
+                            compare_object_array(
+                                vardata[f], d,
+                                "read slice field '%s'" % f,
+                                rows=[2, 3],
+                            )
 
 
 def test_table_iter():
@@ -516,15 +495,15 @@ def test_ascii_table_write_read():
                         ascii_data[f], d, "table field read '%s'" % f
                     )
 
-            rows = [1, 3]
-            for f in ascii_data.dtype.names:
-                d = fits[1].read_column(f, rows=rows)
-                if d.dtype == np.float64:
-                    compare_array_tol(ascii_data[f][rows], d, 2.15e-16,
+            for rows in [[1, 3], [3, 1]]:
+                for f in ascii_data.dtype.names:
+                    d = fits[1].read_column(f, rows=rows)
+                    if d.dtype == np.float64:
+                        compare_array_tol(ascii_data[f][rows], d, 2.15e-16,
+                                          "table field read subrows '%s'" % f)
+                    else:
+                        compare_array(ascii_data[f][rows], d,
                                       "table field read subrows '%s'" % f)
-                else:
-                    compare_array(ascii_data[f][rows], d,
-                                  "table field read subrows '%s'" % f)
 
             beg = 1
             end = 3
@@ -569,27 +548,27 @@ def test_ascii_table_write_read():
                             ascii_data[f], d, "table subcol, '%s'" % f
                         )
 
-            rows = [1, 3]
-            for f in ascii_data.dtype.names:
-                data = fits[1].read(columns=cols, rows=rows)
-                for f in data.dtype.names:
-                    d = data[f]
-                    if d.dtype == np.float64:
-                        compare_array_tol(ascii_data[f][rows], d, 2.15e-16,
+            for rows in [[1, 3], [3, 1]]:
+                for f in ascii_data.dtype.names:
+                    data = fits[1].read(columns=cols, rows=rows)
+                    for f in data.dtype.names:
+                        d = data[f]
+                        if d.dtype == np.float64:
+                            compare_array_tol(ascii_data[f][rows], d, 2.15e-16,
+                                              "table subcol, '%s'" % f)
+                        else:
+                            compare_array(ascii_data[f][rows], d,
                                           "table subcol, '%s'" % f)
-                    else:
-                        compare_array(ascii_data[f][rows], d,
-                                      "table subcol, '%s'" % f)
 
-                data = fits[1][cols][rows]
-                for f in data.dtype.names:
-                    d = data[f]
-                    if d.dtype == np.float64:
-                        compare_array_tol(ascii_data[f][rows], d, 2.15e-16,
+                    data = fits[1][cols][rows]
+                    for f in data.dtype.names:
+                        d = data[f]
+                        if d.dtype == np.float64:
+                            compare_array_tol(ascii_data[f][rows], d, 2.15e-16,
+                                              "table subcol/row, '%s'" % f)
+                        else:
+                            compare_array(ascii_data[f][rows], d,
                                           "table subcol/row, '%s'" % f)
-                    else:
-                        compare_array(ascii_data[f][rows], d,
-                                      "table subcol/row, '%s'" % f)
 
             for f in ascii_data.dtype.names:
 
@@ -923,20 +902,22 @@ def test_table_subsets():
 
             fits.write_table(data, header=adata['keys'], extname='mytable')
 
-            rows = [1, 3]
-            d = fits[1].read(rows=rows)
-            compare_rec_subrows(data, d, rows, "table subset")
-            columns = ['i1scalar', 'f4arr']
-            d = fits[1].read(columns=columns, rows=rows)
+            for rows in [[1, 3], [3, 1]]:
+                d = fits[1].read(rows=rows)
+                compare_rec_subrows(data, d, rows, "table subset")
+                columns = ['i1scalar', 'f4arr']
+                d = fits[1].read(columns=columns, rows=rows)
 
-            for f in columns:
-                d = fits[1].read_column(f, rows=rows)
-                compare_array(
-                    data[f][rows], d, "row subset, multi-column '%s'" % f
-                )
-            for f in data.dtype.names:
-                d = fits[1].read_column(f, rows=rows)
-                compare_array(data[f][rows], d, "row subset, column '%s'" % f)
+                for f in columns:
+                    d = fits[1].read_column(f, rows=rows)
+                    compare_array(
+                        data[f][rows], d, "row subset, multi-column '%s'" % f
+                    )
+                for f in data.dtype.names:
+                    d = fits[1].read_column(f, rows=rows)
+                    compare_array(
+                        data[f][rows], d, "row subset, column '%s'" % f
+                    )
 
 
 def test_gz_write_read():
@@ -1291,14 +1272,14 @@ def test_table_bitcol_read_write():
                 for f in d.dtype.names:
                     compare_array(bdata[f][:], d[f], "test column list %s" % f)
 
-                rows = [1, 3]
-                d = fits[1].read(columns=cols, rows=rows)
-                for f in d.dtype.names:
-                    compare_array(
-                        bdata[f][rows],
-                        d[f],
-                        "test column list %s row subset" % f
-                    )
+                for rows in [[1, 3], [3, 1]]:
+                    d = fits[1].read(columns=cols, rows=rows)
+                    for f in d.dtype.names:
+                        compare_array(
+                            bdata[f][rows],
+                            d[f],
+                            "test column list %s row subset" % f
+                        )
 
 
 def test_table_bitcol_append():

--- a/fitsio/tests/test_table.py
+++ b/fitsio/tests/test_table.py
@@ -71,7 +71,7 @@ def test_table_read_write():
                         adata['data'][f][:], d[f], "test column list %s" % f
                     )
 
-                for rows in [[1, 3], [3, 1]]:
+                for rows in [[1, 3], [3, 1], [2, 2, 1]]:
                     d = fits[1].read(columns=cols, rows=rows)
                     for col in d.dtype.names:
                         compare_array(

--- a/fitsio/tests/test_table.py
+++ b/fitsio/tests/test_table.py
@@ -80,6 +80,25 @@ def test_table_read_write():
                     )
 
 
+def test_table_read_unsorted():
+
+    adata = make_data()
+    data = adata['data']
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, 'test.fits')
+
+        with FITS(fname, 'rw') as fits:
+            fits.write_table(data)
+
+        # now test read_column
+        with FITS(fname) as fits:
+
+            rows = [3, 0, 1]
+            d = fits[1].read(rows=rows)
+            compare_rec(data[rows], d, "unsorted")
+
+
 def test_table_column_index_scalar():
     """
     Test a basic table write, data and a header, then reading back in to

--- a/fitsio/tests/test_table.py
+++ b/fitsio/tests/test_table.py
@@ -98,6 +98,14 @@ def test_table_read_unsorted():
             d = fits[1].read(rows=rows)
             compare_rec(data[rows], d, "unsorted")
 
+            columns = ['f8scalar', 'i4vec', 'i2arr']
+            d = fits[1].read(
+                columns=columns,
+                rows=rows,
+            )
+            for col in columns:
+                compare_array(d[col], data[col][rows], 'unsorted col')
+
 
 def test_table_column_index_scalar():
     """


### PR DESCRIPTION
closes #367 

If the users sends `rows = [3, 1]` the old code returned data for `[1, 3]`.  The data are now returned as requested.

Also previously duplicate rows were removed, no longer.