### PR TITLE
ENH add extra header guards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,9 @@ Changes
 
 Bug Fixes
 
-    - Fixed issue where the patched C fitsio headers were not 
+    - Fixed issue where the patched C fitsio headers were not
       first in the include path.
+    - Added extra header guards and headers to help with compilation issues.
 
 version 1.1.10
 --------------

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -27,7 +27,6 @@
 //#include "fitsio_pywrap_lists.h"
 #include <numpy/arrayobject.h>
 
-
 // this is not defined anywhere in cfitsio except in
 // the fits file structure
 #define CFITSIO_MAX_ARRAY_DIMS 99
@@ -45,8 +44,12 @@ static int fits_use_standard_strings(void)
 {
     return 0;
 }
+#else
+#ifndef _FITSIO_H_FITS_USE_STANDARD_STRINGS
+#define _FITSIO_H_FITS_USE_STANDARD_STRINGS
+int CFITS_API fits_use_standard_strings(void);
 #endif
-
+#endif
 
 // check unicode for python3, string for python2
 int is_python_string(const PyObject* obj)

--- a/patches/fitsio.h.patch
+++ b/patches/fitsio.h.patch
@@ -1,10 +1,13 @@
 --- cfitsio-4.2.0/fitsio.h	2022-10-31 14:40:23.000000000 -0400
 +++ cfitsio-4.2.0/fitsio.h	2023-07-14 11:48:10.102506229 -0400
-@@ -811,6 +811,7 @@
+@@ -811,6 +810,10 @@
  /*---------------- utility routines -------------*/
- 
+
  float CFITS_API ffvers(float *version);
++#ifndef _FITSIO_H_FITS_USE_STANDARD_STRINGS
++#define _FITSIO_H_FITS_USE_STANDARD_STRINGS
 +int CFITS_API fits_use_standard_strings(void);
++#endif
  void CFITS_API ffupch(char *string);
  void CFITS_API ffgerr(int status, char *errtext);
  void CFITS_API ffpmsg(const char *err_message);


### PR DESCRIPTION
This should help with #369. It adds the function declaration if we are bundling cfitsio and we have not included the right header. Note that this situation is very bad in general since the header API may not match, but cfitsio is stable enough that I suspect this is safe enough.