### PR TITLE
fix bug not writing qlevel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Changes
       errors in a FITS file.  Currently this only raises when extensions
       are not properly marked with XTENSION but we can expand this over time
 
+Bug Fixes
+
+    - Bug not writing compression qlevel when it is set to None/0.0
+      This was preventing lossless gzip compression
 
 version 1.2.0
 --------------

--- a/fitsio/__init__.py
+++ b/fitsio/__init__.py
@@ -5,7 +5,7 @@ See the docs at https://github.com/esheldon/fitsio for example
 usage.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 from . import fitslib
 

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1485,10 +1485,8 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
                 goto create_image_hdu_cleanup;
             }
 
-            if (qlevel > 0) {
-                if (fits_set_quantize_level(self->fits, qlevel, &status)) {
-                    goto create_image_hdu_cleanup;
-                }
+            if (fits_set_quantize_level(self->fits, qlevel, &status)) {
+                goto create_image_hdu_cleanup;
             }
 
             if (fits_set_quantize_method(self->fits, qmethod, &status)) {

--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,7 @@ classifiers = [
 
 setup(
     name="fitsio",
-    version="1.2.0",
+    version="1.2.1",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown; charset=UTF-8; variant=GFM',


### PR DESCRIPTION
closes #385 

Even when set to 0 we need to write it.  This support lossless compression

Note however this has uncovered a second bug, where for the lossless gzip compression the data are not being flushed/finalized while the fits object is open