### PR TITLE
When using file-level compression, allow setting compression parameters

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1482,6 +1482,10 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
             write_data=1;
         }
 
+	if (comptype == 0) {
+	    comptype = (*(self->fits)->Fptr).request_compress_type;
+	}
+
         // 0 means NOCOMPRESS but that wasn't defined in the bundled version of cfitsio
         // if (comptype >= 0) {
         if (comptype > 0) {

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -347,6 +347,7 @@ def test_compressed_seed_bad(dither_seed):
                 dither_seed=dither_seed,
             )
 
+
 def test_memory_compressed_seed():
     import fitsio
 
@@ -365,11 +366,11 @@ def test_memory_compressed_seed():
         data = data.astype(dtype)
 
         fitsio.write(fname1, data.copy(), dither_seed='checksum',
-                     compress='RICE', qlevel=1e-4, tile_dims=(100,100), clobber=True)
+                     compress='RICE', qlevel=1e-4, tile_dims=(100, 100),
+                     clobber=True)
         hdr = fitsio.read_header(fname1, ext=1)
         dither1 = hdr['ZDITHER0']
         assert dither1 == 8269
-        #print('File #1: ZDITHER0:', dither1)
 
         fits = fitsio.FITS('mem://[compress R 100,100; qz -1e-4]', 'rw')
         fits.write(data.copy(), dither_seed='checksum')
@@ -380,8 +381,8 @@ def test_memory_compressed_seed():
         f.close()
         hdr = fitsio.read_header(fname2, ext=1)
         dither2 = hdr['ZDITHER0']
-        #print('File #2: ZDITHER0:', dither2)
         assert dither1 == dither2
+
 
 if __name__ == '__main__':
     test_compressed_seed(

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -347,6 +347,41 @@ def test_compressed_seed_bad(dither_seed):
                 dither_seed=dither_seed,
             )
 
+def test_memory_compressed_seed():
+    import fitsio
+
+    dtype = 'f4'
+    nrows = 300
+    ncols = 500
+
+    seed = 1919
+    rng = np.random.RandomState(seed)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname1 = os.path.join(tmpdir, 'test1.fits')
+        fname2 = os.path.join(tmpdir, 'test2.fits')
+
+        data = rng.normal(size=(nrows, ncols))
+        data = data.astype(dtype)
+
+        fitsio.write(fname1, data.copy(), dither_seed='checksum',
+                     compress='RICE', qlevel=1e-4, tile_dims=(100,100), clobber=True)
+        hdr = fitsio.read_header(fname1, ext=1)
+        dither1 = hdr['ZDITHER0']
+        assert dither1 == 8269
+        #print('File #1: ZDITHER0:', dither1)
+
+        fits = fitsio.FITS('mem://[compress R 100,100; qz -1e-4]', 'rw')
+        fits.write(data.copy(), dither_seed='checksum')
+        data = fits.read_raw()
+        fits.close()
+        f = open(fname2, 'wb')
+        f.write(data)
+        f.close()
+        hdr = fitsio.read_header(fname2, ext=1)
+        dither2 = hdr['ZDITHER0']
+        #print('File #2: ZDITHER0:', dither2)
+        assert dither1 == dither2
 
 if __name__ == '__main__':
     test_compressed_seed(


### PR DESCRIPTION
In the `legacypipe` code, we use `mem://` files very extensively -- this allows us to do in-memory checksums before writing to disk.

We also use compression extensively, which we set at the file level via extended filename syntax - eg we create files like
```
fits = fitsio.FITS('mem://[compress R 100,100; qz -1e-4]', 'rw')
```

However, we find that when doing this, when you go to write an image HDU, the compression parameters don't get passed through because `compress=` is not set.

This patch fixes that.

Test case: these two files should get the same `ZDITHER0` set.
```
import numpy as np
import fitsio
A = ((1+np.arange(10000)) * 0.1).astype(np.float32)

fitsio.write('dither1.fits', A.copy(), dither_seed='checksum', compress='RICE', qlevel=1e-4,
             tile_dims=100, clobber=True)
hdr = fitsio.read_header('dither1.fits', ext=1)
print('File #1: ZDITHER0:', hdr['ZDITHER0'])

fits = fitsio.FITS('mem://[compress R 100,100; qz -1e-4]', 'rw')
fits.write(A.copy(), dither_seed='checksum')
data = fits.read_raw()
fits.close()
f = open('dither2.fits', 'wb')
f.write(data)
f.close()
hdr = fitsio.read_header('dither2.fits', ext=1)
print('File #2: ZDITHER0:', hdr['ZDITHER0'])
```
