### PR TITLE
Make sure string column with vec size 1 work

### DIFF
--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -368,17 +368,18 @@ class TableHDU(HDUBase):
         verify the input data is of the correct type and shape
         """
         this_dt = data.dtype.descr[0]
+        npy_type, isvar, istbit = self._get_tbl_numpy_dtype(colnum)
+        is_string = npy_type[0] in ('S', 'U')
 
         if len(data.shape) > 2:
             this_shape = data.shape[1:]
-        elif len(data.shape) == 2 and data.shape[1] > 1:
+        elif len(data.shape) == 2 and (data.shape[1] > 1 or is_string):
             this_shape = data.shape[1:]
         else:
             this_shape = ()
 
         this_npy_type = this_dt[1][1:]
 
-        npy_type, isvar, istbit = self._get_tbl_numpy_dtype(colnum)
         info = self._info['colinfo'][colnum]
 
         if npy_type[0] in ['>', '<', '|']:
@@ -387,7 +388,9 @@ class TableHDU(HDUBase):
         col_name = info['name']
         col_tdim = info['tdim']
         col_shape = _tdim2shape(
-            col_tdim, col_name, is_string=(npy_type[0] == 'S'))
+            col_tdim, col_name,
+            is_string=is_string
+        )
 
         if col_shape is None:
             if this_shape == ():
@@ -1267,7 +1270,7 @@ class TableHDU(HDUBase):
         shape = None
         tdim = info['tdim']
 
-        shape = _tdim2shape(tdim, name, is_string=(npy_type[0] == 'S'))
+        shape = _tdim2shape(tdim, name, is_string=(npy_type[0] in ('S', 'U')))
         if shape is not None:
             if nrows > 1:
                 if not isinstance(shape, tuple):
@@ -1333,7 +1336,8 @@ class TableHDU(HDUBase):
             tdim = self._info['colinfo'][colnum]['tdim']
             shape = _tdim2shape(
                 tdim, name,
-                is_string=(npy_type[0] == 'S' or npy_type[0] == 'U'))
+                is_string=(npy_type[0] in ('S', 'U'))
+            )
             if shape is not None:
                 descr = (name, npy_type, shape)
             else:

--- a/fitsio/tests/test_table.py
+++ b/fitsio/tests/test_table.py
@@ -86,6 +86,108 @@ def test_table_read_write():
                         )
 
 
+@pytest.mark.parametrize('nvec', [2, 1])
+def test_table_read_write_vec1(nvec):
+    """
+    ensure the data for vec length 1 gets round-tripped, even though
+    the shape is not preserved
+    """
+    dtype = [('x', 'f4', (nvec,))]
+    num = 10
+    data = np.zeros(num, dtype=dtype)
+    data['x'] = np.arange(num * nvec).reshape(num, nvec)
+    assert data['x'].shape == (num, nvec)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, 'test.fits')
+
+        with FITS(fname, 'rw') as fits:
+            fits.write_table(data)
+
+            d = fits[1].read()
+            if nvec == 1:
+                assert d['x'].shape == (num,)
+            compare_array(
+                data['x'].ravel(), d['x'].ravel(),
+                "table single field read 'x'"
+            )
+
+        # see if our convenience functions are working
+        write(
+            fname,
+            data,
+            extname="newext",
+        )
+        d = read(fname, ext='newext')
+        if nvec == 1:
+            assert d['x'].shape == (num,)
+        compare_array(data['x'].ravel(), d['x'].ravel(), "table data2")
+
+        # now test read_column
+        with FITS(fname) as fits:
+
+            d = fits[1].read_column('x')
+            if nvec == 1:
+                assert d.shape == (num,)
+            compare_array(
+                data['x'].ravel(), d.ravel(),
+                "table single field read 'x'"
+            )
+
+
+@pytest.mark.parametrize('nvec', [2, 1])
+def test_table_read_write_uvec1(nvec):
+    """
+    ensure the data for U string vec length 1 gets round-tripped, even though
+    the shape is not preserved.  Also test 2 for consistency
+    """
+
+    dtype = [('string', 'U10', (nvec,))]
+    num = 10
+    data = np.zeros(num, dtype=dtype)
+    sravel = data['string'].ravel()
+    sravel[:] = [str(i) for i in range(num * nvec)]
+    assert data['string'].shape == (num, nvec)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, 'test.fits')
+
+        with FITS(fname, 'rw') as fits:
+            fits.write_table(data)
+
+            d = fits[1].read()
+            if nvec == 1:
+                assert d['string'].shape == (num,)
+            compare_array(
+                data['string'].ravel(), d['string'].ravel(),
+                "table single field read 'string'"
+            )
+
+        # see if our convenience functions are working
+        write(
+            fname,
+            data,
+            extname="newext",
+        )
+        d = read(fname, ext='newext')
+        if nvec == 1:
+            assert d['string'].shape == (num,)
+        compare_array(
+            data['string'].ravel(), d['string'].ravel(), "table data2",
+        )
+
+        # now test read_column
+        with FITS(fname) as fits:
+
+            d = fits[1].read_column('string')
+            if nvec == 1:
+                assert d.shape == (num,)
+            compare_array(
+                data['string'].ravel(), d.ravel(),
+                "table single field read 'string'"
+            )
+
+
 def test_table_column_index_scalar():
     """
     Test a basic table write, data and a header, then reading back in to


### PR DESCRIPTION
closes #426 

This fixes a bug where the shape of the column was not correct.

Adds tests that string and number vec1 column data get returned, even though read as scalar