### PR TITLE
fix: pypi uploads broke after setuptools-scm

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -71,6 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -115,6 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -152,6 +154,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -191,6 +194,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -224,7 +228,7 @@ jobs:
 
       - name: publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release' || github.event.action == 'workflow_dispatch'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         with:
           verbose: true
           skip-existing: true


### PR DESCRIPTION
There were some missing refs for the checkout and the upload event did not recognize workflow dispatches.