### PR TITLE
Compression: allow ints

### DIFF
--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1941,7 +1941,7 @@ _compress_map = {
     'PLIO_1': PLIO_1,
     'HCOMPRESS': HCOMPRESS_1,
     'HCOMPRESS_1': HCOMPRESS_1,
-    # In get_compress_type(), we convert the query value to str before searching -
+    # In get_compress_type(), we convert the key to str before searching -
     # so the keys here must be strings also!
     str(NOCOMPRESS): NOCOMPRESS,
     str(RICE_1): RICE_1,


### PR DESCRIPTION
This is part of a larger effort I'm working on around making "Extended Filename Syntax" compression arguments act as defaults to args passed to `write()`.

Currently, the `_compress_map` allows integers keys which map back to strings, which seems like maybe it was intended to allow this map to be used to convert back and forth - but that capability was never used, it's only used in the forward direction.  This change allows one to pass `FITS.write(..., compress=21)`.  I got onto this path because I need to distinguish between "I want no compression" and "I am not changing the compression from its default".  (This PR does not do that.)
