### PR TITLE
fix: properly raise error for unsupported image types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ Bug Fixes
       new patch `patches/imcompress.c.patch`. See https://github.com/HEASARC/cfitsio/pull/97
       for the upstream PR for the patch.
     - Fixed a bug where compression parameters were cached across different HDUs.
+    - Fixed a bug where writing unsupported image types either did not raise an error
+      or did not raise the correct error.
 
 version 1.2.8
 -------------

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1095,7 +1095,7 @@ npy_to_fits_image_types(int npy_dtype, int *fits_img_type, int *fits_datatype) {
 
         case NPY_INT32:
             //*fits_img_type = LONG_IMG;
-            if (sizeof(unsigned short) == sizeof(npy_int32)) {
+            if (sizeof(short) == sizeof(npy_int32)) {
                 *fits_img_type = SHORT_IMG;
                 *fits_datatype = TINT;
             } else if (sizeof(int) == sizeof(npy_int32)) {

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -1095,7 +1095,7 @@ npy_to_fits_image_types(int npy_dtype, int *fits_img_type, int *fits_datatype) {
 
         case NPY_INT32:
             //*fits_img_type = LONG_IMG;
-            if (sizeof(unsigned short) == sizeof(npy_uint32)) {
+            if (sizeof(unsigned short) == sizeof(npy_int32)) {
                 *fits_img_type = SHORT_IMG;
                 *fits_datatype = TINT;
             } else if (sizeof(int) == sizeof(npy_int32)) {
@@ -1394,6 +1394,7 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
     int npy_dtype=0, nkeys=0, write_data=0;
     int i=0;
     int status=0;
+    int py_status=0;
 
     char* extname=NULL;
     int extver=0;
@@ -1450,23 +1451,28 @@ PyFITSObject_create_image_hdu(struct PyFITSObject* self, PyObject* args, PyObjec
                           &hcomp_smooth_obj,
 
                           &extname,
-                          &extver)) {
+                          &extver)
+    ) {
+        py_status = 1;
         goto create_image_hdu_cleanup;
     }
 
     if (array_obj == Py_None) {
         if (create_empty_hdu(self)) {
+            // error string is set in create_empty_hdu
             return NULL;
         }
     } else {
         array = (PyArrayObject *) array_obj;
         if (!PyArray_Check(array)) {
             PyErr_SetString(PyExc_TypeError, "input must be an array.");
+            py_status = 1;
             goto create_image_hdu_cleanup;
         }
 
         npy_dtype = PyArray_TYPE(array);
         if (npy_to_fits_image_types(npy_dtype, &image_datatype, &datatype)) {
+            py_status = 1;
             goto create_image_hdu_cleanup;
         }
 
@@ -1637,7 +1643,7 @@ create_image_hdu_cleanup:
         }
     }
 
-    if (status != 0) {
+    if (status != 0 || py_status != 0) {
         return NULL;
     }
 

--- a/fitsio/tests/test_image.py
+++ b/fitsio/tests/test_image.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import pytest
+
 # import warnings
 from .checks import check_header, compare_array
 import numpy as np
@@ -33,6 +35,18 @@ def test_image_write_read():
         with FITS(fname) as fits:
             for i in range(len(DTYPES)):
                 assert not fits[i].is_compressed(), 'not compressed'
+
+
+def test_image_write_read_bool():
+    rng = np.random.RandomState(seed=10)
+    with FITS("mem://", "rw") as fits:
+        a = rng.rand(10)
+        fits.write(a)
+        a = rng.rand(10) > 0.5
+        with pytest.raises(TypeError) as e:
+            fits.write(a)
+
+    assert "Unsupported numpy image datatype 0" in str(e)
 
 
 def test_image_write_read_unaligned():


### PR DESCRIPTION
This PR ensures we properly raise an error for unsupported image types. It also adds a test.

closes #137 