### PR TITLE
feat: enable free-threading builds

### DIFF
--- a/.github/workflows/tests-external-cfitsio.yml
+++ b/.github/workflows/tests-external-cfitsio.yml
@@ -70,6 +70,7 @@ jobs:
             pytest
             setuptools>=78
             pytest-skip-slow
+            pytest-run-parallel
 
       - name: build external cfitsio
         run: |

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
-          python -m pip install pytest pytest-skip-slow
+          python -m pip install pytest pytest-skip-slow pytest-run-parallel
 
       - name: install bzip2 and other tools on linux
         if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,12 +28,14 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         config:
-          - { pyver: "3.9", npver: "1"}
-          - { pyver: "3.11", npver: "1.26"}
-          - { pyver: "3.12", npver: "1.26"}
-          - { pyver: "3.11", npver: "2.3.0"}
-          - { pyver: "3.12", npver: "2.3.0"}
-          - { pyver: "3.13", npver: "2.3.0"}
+          - { pyver: "3.9", npver: "1", ft: ""}
+          - { pyver: "3.11", npver: "1.26", ft: "python-gil"}
+          - { pyver: "3.12", npver: "1.26", ft: "python-gil"}
+          - { pyver: "3.11", npver: "2", ft: "python-gil"}
+          - { pyver: "3.12", npver: "2", ft: "python-gil"}
+          - { pyver: "3.13", npver: "2", ft: "python-gil"}
+          - { pyver: "3.14", npver: "2", ft: "python-gil"}
+          - { pyver: "3.14", npver: "2", ft: "python-freethreading"}
 
     runs-on: ${{ matrix.os }}
     env:
@@ -63,6 +65,14 @@ jobs:
             pytest
             setuptools>=78
             pytest-skip-slow
+            pytest-run-parallel
+            ${{ matrix.config.ft }}
+
+      - name: set parallel testing flags
+        run: |
+          if [[ "${{ matrix.config.ft }}" == "python-freethreading" ]]; then
+            echo "PRP_FLAGS=--parallel-threads 4 --iterations 4" >> ${GITHUB_ENV}
+          fi
 
       - name: test bundled build
         run: |
@@ -74,11 +84,11 @@ jobs:
           find . -name "*.so" -type f -delete
           pip install ${PIP_OPTIONS} -e .
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            pytest -vv fitsio
+            pytest -vv ${PRP_FLAGS} fitsio
             python -c "import fitsio; assert not fitsio.cfitsio_has_bzip2_support()"
             python -c "import fitsio; assert not fitsio.cfitsio_has_curl_support()"
           else
-            pytest -vv fitsio
+            pytest -vv ${PRP_FLAGS} fitsio
             python -c "import fitsio; assert fitsio.cfitsio_has_bzip2_support()"
             python -c "import fitsio; assert fitsio.cfitsio_has_curl_support()"
           fi
@@ -125,7 +135,7 @@ jobs:
           pushd $dname
 
           pip install ${PIP_OPTIONS} -e .
-          pytest -vv fitsio
+          pytest -vv ${PRP_FLAGS} fitsio
           python -c "import fitsio; assert fitsio.cfitsio_has_bzip2_support()"
           python -c "import fitsio; assert fitsio.cfitsio_has_curl_support()"
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -87,6 +87,7 @@ jobs:
           CIBW_SKIP: ${{ env.CIBW_SKIP_VAL }}
           # I think musl always uses apk, but keep all options available.
           CIBW_BEFORE_ALL: yum install -y bzip2-devel || apt-get install libbz2-dev || apk add --upgrade bzip2-dev
+          CIBW_ENVIRONMENT: 'CFLAGS="-Wno-implicit-function-declaration -Wno-int-conversion"'
 
       - uses: jirutka/setup-alpine@v1
         with:

--- a/README.md
+++ b/README.md
@@ -483,6 +483,20 @@ in Python 3 will now come back as a string and not a byte string. Note that this
 support is not the same as full unicode support. Internally, fitsio only supports
 the ASCII character set.
 
+## Thread Safety and Python Free Threading
+
+`fitsio` is a Python wrapper for the `cfitsio` library and so inherits the constraints
+on multithreaded programs from `cfitsio`. Specifically this means that
+
+- `fitsio.FITS` file objects are NOT thread-safe and should never be shared between threads.
+- Concurrent reading from FITS files is thread-safe, but every thread must open the FITS file
+  on its own, getting unique `fitsio.FITS` object.
+- Concurrent writing to FITS files is NOT thread-safe.
+
+`fitsio` is compatible with Python free threading, and will not reenable the GIL
+when imported. However, the constraints above must be respected even when using Python
+free threading.
+
 ## TODO
 
 - HDU groups: does anyone use these? If so open an issue!

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -5430,6 +5430,13 @@ init_fitsio_wrap(void)
     PyModule_AddObject(m, "FITS", (PyObject *)&PyFITSType);
 
     import_array();
+
+#if PY_MAJOR_VERSION >= 3
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+#endif
+
 #if PY_MAJOR_VERSION >= 3
     return m;
 #endif

--- a/fitsio/tests/test_header.py
+++ b/fitsio/tests/test_header.py
@@ -443,6 +443,7 @@ DATASUM =                      / checksum of the data records\n"""
         hdr.add_record(line)
 
 
+@pytest.mark.thread_unsafe
 def test_corrupt_continue():
     """
     test with corrupt continue, just make sure it doesn't crash

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -610,6 +610,8 @@ def test_image_mem_reopen_noop():
         assert np.array_equal(rimg, img)
 
 
+@pytest.mark.parallel_threads_limit(1)
+@pytest.mark.iterations(1)
 @pytest.mark.parametrize(
     "coef",
     [

--- a/fitsio/tests/test_table.py
+++ b/fitsio/tests/test_table.py
@@ -1575,8 +1575,7 @@ def test_table_big_col(table_type):
                 write(pth, d, table_type=table_type)
             assert "FITSIO status = 236: column exceeds width of table" in str(
                 e.value
-            )
-            assert (
+            ) or (
                 "string column is too wide: 70000; "
                 "max supported width is" in str(e.value)
             )

--- a/fitsio/tests/test_warnings.py
+++ b/fitsio/tests/test_warnings.py
@@ -5,7 +5,10 @@ import numpy as np
 from ..fitslib import FITS
 from ..util import FITSRuntimeWarning
 
+import pytest
 
+
+@pytest.mark.thread_unsafe
 def test_non_standard_key_value():
     with tempfile.TemporaryDirectory() as tmpdir:
         fname = os.path.join(tmpdir, 'test.fits')

--- a/setup.py
+++ b/setup.py
@@ -369,6 +369,7 @@ class build_ext_subclass(build_ext):
         args = [
             '--without-fortran',
             '--disable-shared',
+            '--enable-reentrant',
         ]
         our_cflags = "-fPIC -fvisibility=hidden"
 


### PR DESCRIPTION
This PR enables python free-threading builds and add tests for them. 

The changes here mean that the package won't reenable the GIL when imported. 

However, there are some important limitations that are fundamental:

- `cfitsio` does not support more than one thread using a given file pointer. Thus `fitsio` won't have support either. As usual with file-related potential race conditions, we leave this to the user to manage.
- Even in free-threaded python, a you have to call the functions that detach the thread state in order to get performance gains for blocking i/o operations, etc. See this bit in the python manual (https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock)

  > For [free-threaded](https://docs.python.org/3/glossary.html#term-free-threading) builds, the [GIL](https://docs.python.org/3/glossary.html#term-GIL) is normally out of the question, but detaching the [thread state](https://docs.python.org/3/glossary.html#term-attached-thread-state) is still required for blocking I/O and long operations.

  So confusingly, we still need to "release the GIL" per #476 even in a free-threaded build. For this PR, I am punting on this task to a future PRs.


Edit: The code snippet below does not work. I have another solution in another PR, but we can punt for now.

~We could use the ideas [here](https://py-free-threading.github.io/porting/#raising-errors-under-shared-concurrent-use) to raise errors on concurrent use of FITS objects from more than one thread. I will leave this to a potential future PR if we think it is worth the complexity.~

