### PR TITLE
feat: lock access to underlying cfitsio object

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -573,6 +573,7 @@ static void PyFITSObject_dealloc(struct PyFITSObject *self) {
     if (self->fits != NULL) {
         check_py_fits_object_same_thread(self);
         fits_close_file(self->fits, &status);
+        self->fits = NULL;
     }
 #if PY_MAJOR_VERSION >= 3
     // introduced in python 2.6

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -447,7 +447,7 @@ static int check_py_fits_object_same_thread(struct PyFITSObject *self) {
 
     if (self->thread_native_id != curr_thread_native_id) {
         PyErr_SetString(PyExc_RuntimeError,
-                        "Shared use of FITS object between objects detected! "
+                        "Shared use of FITS object between threads detected! "
                         "`cfitsio` does NOT support shared use of FITS file "
                         "pointers! You can read from the same FITS file with "
                         "multiple threads, but each threads to open the file "

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -533,12 +533,12 @@ class _CFITS(_fitsio_wrap.FITS):
         self._lock = threading.RLock()
 
     def __getattribute__(self, name):
-        if not self._lock.acquire(blocking=False):
+        if not object.__getattribute__(self, "_lock").acquire(blocking=False):
             raise RuntimeError("Concurrent use of FITS object detected!")
         try:
             return object.__getattribute__(self, name)
         finally:
-            self._lock.release()
+            object.__getattribute__(self, "_lock").release()
 
 
 class FITS(object):

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -23,7 +23,6 @@ See the main docs at https://github.com/esheldon/fitsio
 
 from __future__ import with_statement, print_function
 import os
-
 import numpy
 
 from . import _fitsio_wrap

--- a/fitsio/tests/test_freethreading.py
+++ b/fitsio/tests/test_freethreading.py
@@ -24,10 +24,7 @@ def test_concurrent_shared_usage_raises():
             assert (res == 1).all()
 
             with ThreadPoolExecutor(max_workers=2) as exc:
-                futs = [
-                    exc.submit(_read_data, fp)
-                    for _ in range(2)
-                ]
+                futs = [exc.submit(_read_data, fp) for _ in range(2)]
 
                 for fut in as_completed(futs):
                     with pytest.raises(RuntimeError) as e:

--- a/fitsio/tests/test_freethreading.py
+++ b/fitsio/tests/test_freethreading.py
@@ -1,0 +1,35 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import os
+import tempfile
+
+import numpy as np
+
+import pytest
+
+import fitsio
+
+
+def test_concurrent_shared_usage_raises():
+    def _read_data(fp):
+        return fp[0].read()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, "fname.fits")
+
+        with fitsio.FITS(fname, "rw", clobber=True) as fp:
+            fp.write_image(np.ones((1000, 100)))
+
+        with fitsio.FITS(fname, "r") as fp:
+            res = fp[0].read()
+            assert (res == 1).all()
+
+            with ThreadPoolExecutor(max_workers=2) as exc:
+                futs = [
+                    exc.submit(_read_data, fp)
+                    for _ in range(2)
+                ]
+
+                for fut in as_completed(futs):
+                    with pytest.raises(RuntimeError) as e:
+                        fut.result()
+                    assert "Concurrent" in str(e.value)

--- a/fitsio/tests/test_freethreading.py
+++ b/fitsio/tests/test_freethreading.py
@@ -30,6 +30,6 @@ def test_concurrent_shared_usage_raises():
                     with pytest.raises(RuntimeError) as e:
                         fut.result()
                     assert (
-                        "Shared use of FITS object between objects detected!"
+                        "Shared use of FITS object between threads detected!"
                         in str(e.value)
                     )

--- a/fitsio/tests/test_freethreading.py
+++ b/fitsio/tests/test_freethreading.py
@@ -29,4 +29,7 @@ def test_concurrent_shared_usage_raises():
                 for fut in as_completed(futs):
                     with pytest.raises(RuntimeError) as e:
                         fut.result()
-                    assert "Concurrent" in str(e.value)
+                    assert (
+                        "Shared use of FITS object between objects detected!"
+                        in str(e.value)
+                    )

--- a/fitsio/tests/test_freethreading.py
+++ b/fitsio/tests/test_freethreading.py
@@ -10,7 +10,7 @@ import fitsio
 def test_locking_works():
     rng = np.random.RandomState(seed=10)
     img = rng.normal(size=(1000, 1000))
-    max_workers = 100
+    max_workers = 2
 
     def _read_data(fp):
         return fp[0].read()


### PR DESCRIPTION
This PR adds locks to prevent concurrent usage of the cfitsio object.

See https://py-free-threading.github.io/porting/#raising-errors-under-shared-concurrent-use.

There are a lot of potential issues here, but the main ones are that 

- I have not structured the locks to ensure key operations are atomic.
- How the locks should be structured likely depends on the exact use case.

In other words, while I have ensured that no thread uses the same cfitsio file pointer at the same time, I have not ensured that a given thread can lock all of the python+C data structures long enough to do a fully consistent operation.

So for example, the lock is not held long enough for the thread to write image data via the C layer and also update the HDU list in the python layer.

So the locks as they are implemented now are formally correct, but don't really help the user  avoid important race conditions. 