### PR TITLE
fix: test has wrong version constraint

### DIFF
--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -620,10 +620,10 @@ def test_image_mem_reopen_noop():
             2,
             marks=[
                 pytest.mark.xfail(
-                    condition=CFITSIO_VERSION < 4.4,
+                    condition=CFITSIO_VERSION < 4.04,
                     reason=(
                         "Writing compressed binary tables exceeding "
-                        "2**32 bytes fails for cfitsio < 4.40!"
+                        "2**32 bytes fails for cfitsio < 4.040!"
                     ),
                 ),
                 pytest.mark.slow,


### PR DESCRIPTION
cfitsio uses a factor of 100 to translate the minor version into a version string. So we need 4.04, not 4.4 here.