### PR TITLE
test_compression_diskfile_kwargs: support both RICE_ONE and RICE_1

### DIFF
--- a/fitsio/tests/test_image_compression_defaults.py
+++ b/fitsio/tests/test_image_compression_defaults.py
@@ -37,9 +37,10 @@ def test_compression_diskfile_kwargs():
             ('ZTILE2', 10),
             ('ZQUANTIZ', 'SUBTRACTIVE_DITHER_2'),
             ('ZDITHER0', 42),
-            ('ZCMPTYPE', 'RICE_ONE'),
         ]:
             assert hdr[key] == val
+        # Starting with cfitsio 4.6.4, RICE_1 is returned instead of RICE_ONE
+        assert hdr['ZCMPTYPE'] in ('RICE_ONE', 'RICE_1')
 
 
 def test_compression_efns():


### PR DESCRIPTION
Starting with CFITSIO 4.6.4, commit 7d854ef29a4c ("Stop writing RICE_ONE as an alias for RICE_1."), the ZCMPTYPE header returns RICE_1 instead of RICE_ONE, breaking the test_compression_diskfile_kwargs test. Update it to accept both values to maintain compatibility across CFITSIO versions.