### PR TITLE
Add second patch to imcompress.c limiting cache to one tile

### DIFF
--- a/patches/fitscore.c.patch
+++ b/patches/fitscore.c.patch
@@ -1,0 +1,62 @@
+--- fitscore.c	2025-09-22 11:49:36.000000000 -0400
++++ fitscore.c	2026-05-08 14:51:48.824886391 -0400
+@@ -4647,8 +4647,9 @@
+ 
+         /* free the tile-compressed image cache, if it exists */
+         if ((fptr->Fptr)->tilerow) {
+-           ntilebins = 
+-	    (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1;
++        /*    ntilebins =  */
++	    /* (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1; */
++           ntilebins = 1;
+ 
+            for (ii = 0; ii < ntilebins; ii++) {
+              if ((fptr->Fptr)->tiledata[ii]) {
+@@ -4701,8 +4702,9 @@
+         /* free the tile-compressed image cache, if it exists */
+         if ((fptr->Fptr)->tilerow) {
+ 
+-           ntilebins = 
+-	    (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1;
++        /*    ntilebins =  */
++	    /* (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1; */
++           ntilebins = 1;
+ 
+            for (ii = 0; ii < ntilebins; ii++) {
+              if ((fptr->Fptr)->tiledata[ii]) {
+@@ -4813,8 +4815,9 @@
+      /* free the tile-compressed image cache, if it exists */
+      if ((fptr->Fptr)->tilerow) {
+ 
+-           ntilebins = 
+-	    (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1;
++        /*    ntilebins =  */
++	    /* (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1; */
++           ntilebins = 1;
+ 
+            for (ii = 0; ii < ntilebins; ii++) {
+              if ((fptr->Fptr)->tiledata[ii]) {
+@@ -5022,8 +5025,9 @@
+      /* free the tile-compressed image cache, if it exists */
+      if ((fptr->Fptr)->tilerow) {
+ 
+-           ntilebins = 
+-	    (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1;
++        /*    ntilebins =  */
++	    /* (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1; */
++           ntilebins = 1;
+ 
+            for (ii = 0; ii < ntilebins; ii++) {
+              if ((fptr->Fptr)->tiledata[ii]) {
+@@ -6712,8 +6716,9 @@
+           /* free the tile-compressed image cache, if it exists */
+           if ((fptr->Fptr)->tilerow) {
+ 
+-           ntilebins = 
+-	    (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1;
++        /*    ntilebins =  */
++	    /* (((fptr->Fptr)->znaxis[0] - 1) / ((fptr->Fptr)->tilesize[0])) + 1; */
++           ntilebins = 1;
+ 
+            for (ii = 0; ii < ntilebins; ii++) {
+              if ((fptr->Fptr)->tiledata[ii]) {

--- a/patches/imcompress-cache.c.patch
+++ b/patches/imcompress-cache.c.patch
@@ -1,0 +1,32 @@
+--- imcompress.c	2025-09-22 11:49:36.000000000 -0400
++++ imcompress.c	2026-05-08 14:51:48.824886391 -0400
+@@ -1825,7 +1825,8 @@
+     if ((outfptr->Fptr)->tilerow) {  /* has the tile cache been allocated? */
+ 
+       /* calculate the column bin of the compressed tile */
+-      tilecol = (row - 1) % ((long)(((outfptr->Fptr)->znaxis[0] - 1) / ((outfptr->Fptr)->tilesize[0])) + 1);
++      // tilecol = (row - 1) % ((long)(((outfptr->Fptr)->znaxis[0] - 1) / ((outfptr->Fptr)->tilesize[0])) + 1);
++      tilecol = 0;
+       
+       if ((outfptr->Fptr)->tilerow[tilecol] == row) {
+         if (((outfptr->Fptr)->tiledata)[tilecol]) {
+@@ -5917,7 +5918,8 @@
+     if ((infptr->Fptr)->tilerow == 0)  {
+ 
+       /* calculate number of column bins of compressed tile */
+-      ntilebins =  (((infptr->Fptr)->znaxis[0] - 1) / ((infptr->Fptr)->tilesize[0])) + 1;
++      // ntilebins =  (((infptr->Fptr)->znaxis[0] - 1) / ((infptr->Fptr)->tilesize[0])) + 1;
++      ntilebins = 1;
+ 
+      if ((infptr->Fptr)->znaxis[0]   != (infptr->Fptr)->tilesize[0] ||
+         (infptr->Fptr)->tilesize[1] != 1 ) {   /* don't cache the tile if only single row of the image */
+@@ -5935,7 +5937,8 @@
+     /* check if this tile was cached; if so, just copy it out */
+     if ((infptr->Fptr)->tilerow)  {
+       /* calculate the column bin of the compressed tile */
+-      tilecol = (nrow - 1) % ((long)(((infptr->Fptr)->znaxis[0] - 1) / ((infptr->Fptr)->tilesize[0])) + 1);
++      // tilecol = (nrow - 1) % ((long)(((infptr->Fptr)->znaxis[0] - 1) / ((infptr->Fptr)->tilesize[0])) + 1);
++      tilecol = 0;
+ 
+       if (nrow == (infptr->Fptr)->tilerow[tilecol] && datatype == (infptr->Fptr)->tiletype[tilecol] ) {
+ 

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,8 @@ class build_ext_subclass(build_ext):
         patches = glob.glob('%s/*.patch' % self.cfitsio_patch_dir)
         for patch in patches:
             fname = os.path.basename(patch.replace('.patch', ''))
+            if fname == 'imcompress-cache.c':
+                fname = 'imcompress.c'
             try:
                 subprocess.check_call(
                     [


### PR DESCRIPTION
The old compressed tile cache could grow large.  This limits it to size one tile, addressing the main performance gain from the cache.

closes #492 