### PR TITLE
fix: put back patches to prevent underflows from being cast to zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ fitsio/_version.py
 .ruff_cache
 
 prof/
+
+.DS_Store
+cfitsio-*/
+zlib/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Changes
 - Added development dependencies to the `pyproject.toml`.
 - Reformatted `CHANGES.md` for clarity and added linting
   to ensure consistent formatting in the future.
+- Added back patch of `cfitsio` to prevent subnormal floats from being
+  cast to zero for bundled builds.
 
 Bug Fixes
 

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -887,6 +887,24 @@ def test_image_compression_read_from_osx_arm64():
     np.testing.assert_array_equal(data, cdata)
 
 
+def test_image_compression_gzip_subnormal_cast_to_zero():
+    data = np.zeros(
+        (5, 1), dtype='>f4'
+    )  # a single 5x1 tile, big-endian float32
+    data[:, 0] = [134.97459, 248.02034, 183.40105, 57.59670, 216.31425]
+
+    fn = "mini.fits"
+    if os.path.exists(fn):
+        os.remove(fn)
+    with FITS(fn, "rw") as f:
+        f.write(
+            data, compress="GZIP_1", tile_dims=(5, 1), qlevel=5, qmethod=-1
+        )
+
+    back = FITS(fn)[1].read()
+    assert not back.ravel()[0] == 0, back.ravel()
+
+
 if __name__ == '__main__':
     test_compressed_seed(
         compress='rice',

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -792,8 +792,9 @@ def test_image_compression_nulls_patches_with_subnormal(
                 # however, on read, we send nullcheck=NAN and as a side
                 # effect the subnormal float value in this row gets truncated
                 # to zero
-                np.testing.assert_array_equal(read_data[1, 1:], 0.0)
-                np.testing.assert_array_equal(read_slice1[1:], 0.0)
+                if not cfitsio_is_bundled():
+                    np.testing.assert_array_equal(read_data[1, 1:], 0.0)
+                    np.testing.assert_array_equal(read_slice1[1:], 0.0)
 
                 # this does not happen for row index 2 which doesn't have
                 # subnormal float values
@@ -888,21 +889,24 @@ def test_image_compression_read_from_osx_arm64():
 
 
 def test_image_compression_gzip_subnormal_cast_to_zero():
+    # test code from astrofrog in https://github.com/esheldon/fitsio/issues/513
     data = np.zeros(
         (5, 1), dtype='>f4'
     )  # a single 5x1 tile, big-endian float32
     data[:, 0] = [134.97459, 248.02034, 183.40105, 57.59670, 216.31425]
 
-    fn = "mini.fits"
-    if os.path.exists(fn):
-        os.remove(fn)
-    with FITS(fn, "rw") as f:
-        f.write(
-            data, compress="GZIP_1", tile_dims=(5, 1), qlevel=5, qmethod=-1
-        )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fn = os.path.join(tmpdir, "mini.fit")
+        with FITS(fn, "rw") as f:
+            f.write(
+                data, compress="GZIP_1", tile_dims=(5, 1), qlevel=5, qmethod=-1
+            )
 
-    back = FITS(fn)[1].read()
-    assert not back.ravel()[0] == 0, back.ravel()
+        back = read(fn)
+        if cfitsio_is_bundled():
+            assert not back.ravel()[0] == 0, back.ravel()
+        else:
+            assert back.ravel()[0] == 0, back.ravel()
 
 
 if __name__ == '__main__':

--- a/patches/getcold.c.patch
+++ b/patches/getcold.c.patch
@@ -1,0 +1,38 @@
+--- a/getcold.c
++++ b/getcold.c
+@@ -1418,7 +1418,7 @@ int fffr4r8(float *input,         /* I - array of values to be converted     */
+                         nullarray[ii] = 1;
+                   }
+                   else            /* it's an underflow */
+-                     output[ii] = 0;
++                     output[ii] = (double) input[ii];
+               }
+               else
+                 output[ii] = (double) input[ii];
+@@ -1439,7 +1439,7 @@ int fffr4r8(float *input,         /* I - array of values to be converted     */
+                         nullarray[ii] = 1;
+                   }
+                   else            /* it's an underflow */
+-                     output[ii] = zero;
++                     output[ii] = input[ii] * scale + zero;
+               }
+               else
+                   output[ii] = input[ii] * scale + zero;
+@@ -1519,7 +1519,7 @@ int fffr8r8(double *input,        /* I - array of values to be converted     */
+                     }
+                   }
+                   else            /* it's an underflow */
+-                     output[ii] = 0;
++                     output[ii] = input[ii];
+               }
+               else
+                   output[ii] = input[ii];
+@@ -1544,7 +1544,7 @@ int fffr8r8(double *input,        /* I - array of values to be converted     */
+                     }
+                   }
+                   else            /* it's an underflow */
+-                     output[ii] = zero;
++                     output[ii] = input[ii] * scale + zero;
+               }
+               else
+                   output[ii] = input[ii] * scale + zero;

--- a/patches/getcole.c.patch
+++ b/patches/getcole.c.patch
@@ -1,0 +1,40 @@
+--- a/getcole.c
++++ b/getcole.c
+@@ -1425,7 +1425,7 @@ int fffr4r4(float *input,         /* I - array of values to be converted     */
+                     }
+                   }
+                   else            /* it's an underflow */
+-                     output[ii] = 0;
++                     output[ii] = input[ii];
+               }
+               else
+                 output[ii] = input[ii];
+@@ -1450,7 +1450,7 @@ int fffr4r4(float *input,         /* I - array of values to be converted     */
+                     }
+                   }
+                   else            /* it's an underflow */
+-                     output[ii] = (float) zero;
++                     output[ii] = (float) (input[ii] * scale + zero);
+               }
+               else
+                   output[ii] = (float) (input[ii] * scale + zero);
+@@ -1549,8 +1549,8 @@ int fffr8r4(double *input,        /* I - array of values to be converted     */
+                     else
+                         nullarray[ii] = 1;
+                   }
+-                  else            /* it's an underflow */
+-                     output[ii] = 0;
++                  else
++                    output[ii] = (float) input[ii];
+               }
+               else
+               {
+@@ -1596,7 +1596,7 @@ int fffr8r4(double *input,        /* I - array of values to be converted     */
+                         output[ii] = FLT_MAX;
+                      }
+                      else
+-                        output[ii] = (float) zero;
++                        output[ii] = (float) (input[ii] * scale + zero);
+                    }
+               }
+               else


### PR DESCRIPTION
This PR demonstrates that restoring the compression patches solves issue #513.