### PR TITLE
fix: ensure hdu list and hdu map are in sync

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Changes
 
 Bug Fixes
 
-- Fixed (rare) bug where `hdu_list` and `hdu_map` can go out of sync.
+- Fixed (rare) bug where `FITS.hdu_list` and `FITS.hdu_map` can go out of sync.
 
 ## 1.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ Changes
 - Reformatted `CHANGES.md` for clarity and added linting
   to ensure consistent formatting in the future.
 
+Bug Fixes
+
+- Fixed (rare) bug where `hdu_list` and `hdu_map` can go out of sync.
+
 ## 1.4.0
 
 Changes

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -1460,7 +1460,7 @@ class FITS(object):
         if rebuild is false or the hdu_list is not yet set, the list is
         rebuilt from scratch
         """
-        if not hasattr(self, 'hdu_list'):
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
             rebuild = True
 
         if rebuild:
@@ -1547,7 +1547,7 @@ class FITS(object):
         """
         begin iteration over HDUs
         """
-        if not hasattr(self, 'hdu_list'):
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
             self.update_hdu_list()
         self._iter_index = 0
         return self
@@ -1568,7 +1568,7 @@ class FITS(object):
         """
         get the number of extensions
         """
-        if not hasattr(self, 'hdu_list'):
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
             self.update_hdu_list()
         return len(self.hdu_list)
 
@@ -1594,7 +1594,7 @@ class FITS(object):
         """
         Get an hdu by number, name, and possibly version
         """
-        if not hasattr(self, 'hdu_list'):
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
             if self._did_create:
                 # we created the file and haven't written anything yet
                 raise ValueError("Requested hdu '%s' not present" % item)
@@ -1655,7 +1655,7 @@ class FITS(object):
 
         rep.append('%sextnum %-15s %s' % (spacing, "hdutype", "hduname[v]"))
 
-        if not hasattr(self, 'hdu_list'):
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
             if not self._did_create:
                 # we expect some stuff
                 self.update_hdu_list()


### PR DESCRIPTION
This is a rare bug that occurred randomly during one of the recent CI runs. I do not know exactly how it happened, but the symptom was that `hdu_map` was missing while `hdu_list` was present. This PR ensures that if either is missing, which should never happen (but apparently did...), both are rebuilt.