### PR TITLE
fix: ensure we use a global lock on cfitsio calls when library is not reentrant

### DIFF
--- a/.github/workflows/tests-external-cfitsio.yml
+++ b/.github/workflows/tests-external-cfitsio.yml
@@ -155,6 +155,11 @@ jobs:
           else
             python -c "import fitsio; assert fitsio.cfitsio_has_curl_support()"
           fi
+          if [[ "${{ matrix.config.cf}}" != "" ]]; then
+            python -c "import fitsio; assert fitsio.cfitsio_is_reentrant()"
+          else
+            python -c "import fitsio; assert not fitsio.cfitsio_is_reentrant()"
+          fi
 
           pytest -vv --durations=20 ${PRP_FLAGS} fitsio
 

--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -63,3 +63,4 @@ jobs:
           pytest -vv --durations=20 --slow fitsio
           python -c "import fitsio; assert fitsio.cfitsio_has_bzip2_support()"
           python -c "import fitsio; assert fitsio.cfitsio_has_curl_support()"
+          python -c "import fitsio; assert fitsio.cfitsio_is_reentrant()"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
             python -c "import fitsio; assert fitsio.cfitsio_has_bzip2_support()"
             python -c "import fitsio; assert fitsio.cfitsio_has_curl_support()"
           fi
+          python -c "import fitsio; assert fitsio.cfitsio_is_reentrant()"
 
       - name: install bzip2 and curl on linux
         if: matrix.os == 'ubuntu-latest'
@@ -142,6 +143,7 @@ jobs:
           pytest -vv --durations=20 ${PRP_FLAGS} fitsio
           python -c "import fitsio; assert fitsio.cfitsio_has_bzip2_support()"
           python -c "import fitsio; assert fitsio.cfitsio_has_curl_support()"
+          python -c "import fitsio; assert fitsio.cfitsio_is_reentrant()"
 
           popd
           popd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,13 @@ Changes
 - Added development dependencies to the `pyproject.toml`.
 - Reformatted `CHANGES.md` for clarity and added linting
   to ensure consistent formatting in the future.
+- Added function `cfitsio_is_reentrant()` to return whether or not the
+  underlying cfitsio library was compiled with reentrant support.
 
 Bug Fixes
 
 - Fixed (rare) bug where `FITS.hdu_list` and `FITS.hdu_map` can go out of sync.
+- Added global lock on `cfitsio` calls for non-reentrant builds.
 
 ## 1.4.0
 

--- a/fitsio/__init__.py
+++ b/fitsio/__init__.py
@@ -41,6 +41,10 @@ from .util import (
     FITSRuntimeWarning,
     cfitsio_is_bundled,
 )
-from ._fitsio_wrap import cfitsio_has_bzip2_support, cfitsio_has_curl_support
+from ._fitsio_wrap import (
+    cfitsio_has_bzip2_support,
+    cfitsio_has_curl_support,
+    cfitsio_is_reentrant,
+)
 
 from .fits_exceptions import FITSFormatError

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -44,8 +44,12 @@ for details on how to use these macros.
 */
 #if (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 13)
 #define PYFITS_HAS_LOCK
-#define LOCK_FITS(x) PyMutex_Lock(&(x->fits_lock))
-#define UNLOCK_FITS(x) PyMutex_Unlock(&(x->fits_lock))
+#define LOCK_FITS(x)                                                           \
+    (fits_is_reentrant() == 0 ? PyMutex_Lock(&GLOBAL_FITS_LOCK)                \
+                              : PyMutex_Lock(&(x->fits_lock)))
+#define UNLOCK_FITS(x)                                                         \
+    (fits_is_reentrant() == 0 ? PyMutex_Unlock(&GLOBAL_FITS_LOCK)              \
+                              : PyMutex_Unlock(&(x->fits_lock)))
 #define ALLOW_NOGIL                                                            \
     PyThreadState *_save1_ = NULL;                                             \
     int _evaltmp123_
@@ -67,6 +71,11 @@ for details on how to use these macros.
 #define RELEASE_GIL
 #define CAPTURE_GIL
 #define NOGIL(x) (x)
+#endif
+
+#ifdef PYFITS_HAS_LOCK
+// global lock for cfitsio when library is not reentrant
+static PyMutex GLOBAL_FITS_LOCK = {0};
 #endif
 
 struct PyFITSObject {
@@ -5804,6 +5813,14 @@ static PyObject *PyFITS_cfitsio_null_value_for_nan(void) {
     return PyFloat_FromDouble((double)INFINITY);
 }
 
+static PyObject *PyFITS_cfitsio_is_reentrant(void) {
+    if (fits_is_reentrant() == 0) {
+        Py_RETURN_FALSE;
+    } else {
+        Py_RETURN_TRUE;
+    }
+}
+
 /*
 
 'C',              'L',     'I',     'F'             'X'
@@ -6110,6 +6127,10 @@ static PyMethodDef fitstype_methods[] = {
      (PyCFunction)PyFITS_cfitsio_null_value_for_nan, METH_NOARGS,
      "cfitsio_null_value_for_nan\n\nReturn our default null value for "
      "floats, which is INFINITY and/or np.inf"},
+    {"cfitsio_is_reentrant", (PyCFunction)PyFITS_cfitsio_is_reentrant,
+     METH_NOARGS,
+     "cfitsio_is_reentrant\n\nReturn True if cfitsio was compiled with "
+     "reentrant support."},
     {"parse_card", (PyCFunction)PyFITS_parse_card, METH_VARARGS,
      "parse_card\n\nparse the card to get the key name, value (as a string), "
      "data type and comment."},


### PR DESCRIPTION
For non-reentrant builds, only one thread can call `cfitsio` functions at a time. The GIL has (I think) enforced this as a side effect since we did not release it. Now that we do release it in Python 3.13 or above, we need the extra guard. I also added a function to return whether the underlying cfitsio library is reentrant at the Python level for testing, debugging, etc.