### PR TITLE
test: mark tests of reproducible lossy compression as xfail for external builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Changes
 Bug Fixes
 
 - Fixed (rare) bug where `FITS.hdu_list` and `FITS.hdu_map` can go out of sync.
+- Marked tests for reproducible lossy float compression as xfail for external
+  cfitsio libraries.
 
 ## 1.4.0
 

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -842,6 +842,13 @@ def test_image_compression_read_chunks():
                 assert np.all(read_data == data[start:end])
 
 
+@pytest.mark.xfail(
+    condition=not cfitsio_is_bundled(),
+    reason=(
+        "system cfitsio must be compiled without FMA instructions to "
+        "enable reproducible lossy float compression"
+    ),
+)
 def test_image_compression_write_read_comp_to_osx_arm64():
     pth = os.path.join(
         os.path.dirname(__file__),
@@ -868,6 +875,13 @@ def test_image_compression_write_read_comp_to_osx_arm64():
     np.testing.assert_array_equal(data, tdata)
 
 
+@pytest.mark.xfail(
+    condition=not cfitsio_is_bundled(),
+    reason=(
+        "system cfitsio must be compiled without FMA instructions to "
+        "enable reproducible lossy float compression"
+    ),
+)
 def test_image_compression_read_from_osx_arm64():
     pth = os.path.join(
         os.path.dirname(__file__),


### PR DESCRIPTION
This PR fixes #512 where the lossy compression reproducibility test can fail for external builds.