### PR TITLE
fix: skip tests for big compressed images on 32-bit platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Bug Fixes
 - Added global lock on `cfitsio` calls for non-reentrant builds.
 - Marked tests for reproducible lossy float compression as xfail for external
   cfitsio libraries.
+- Skip tests for large compressed images exceeding `2**32` bytes on 32-bit platforms.
 
 ## 1.4.0
 

--- a/fitsio/tests/test_image_compression.py
+++ b/fitsio/tests/test_image_compression.py
@@ -1,4 +1,5 @@
 import pytest
+import struct
 import sys
 import os
 import tempfile
@@ -610,6 +611,13 @@ def test_image_mem_reopen_noop():
         assert np.array_equal(rimg, img)
 
 
+@pytest.mark.skipif(
+    condition=struct.calcsize("P") * 8 == 32,
+    reason=(
+        "Cannot test writing of compressed tables "
+        "with more than 2**32 bytes on 32-bit platforms"
+    ),
+)
 @pytest.mark.slow
 @pytest.mark.parallel_threads_limit(1)
 @pytest.mark.iterations(1)


### PR DESCRIPTION
As it says on the tin...

closes #520 