### PR TITLE
fix: lock updates to python object attributes

### DIFF
--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -612,6 +612,49 @@ static PyObject *PyFITSObject_close(struct PyFITSObject *self) {
     Py_RETURN_NONE;
 }
 
+static PyObject *PyFITSObject_reopen(struct PyFITSObject *self) {
+    ALLOW_NOGIL;
+    int status = 0;
+    int istatus = 0;
+    fitsfile *old_fits = NULL;
+
+    LOCK_FITS(self);
+
+    if (self->fits == NULL) {
+        PyErr_SetString(PyExc_ValueError, "could not reopen FITS file!");
+        UNLOCK_FITS(self);
+        return NULL;
+    }
+
+    RELEASE_GIL;
+
+    old_fits = self->fits;
+    if (fits_reopen_file(old_fits, &self->fits, &status)) {
+        fits_close_file(self->fits, &status);
+        if (self->fits != NULL) {
+            istatus = 0;
+            fits_close_file(self->fits, &istatus);
+            self->fits = NULL;
+        }
+        if (old_fits != NULL) {
+            istatus = 0;
+            fits_close_file(old_fits, &istatus);
+        }
+        CAPTURE_GIL;
+        PyErr_SetString(PyExc_ValueError, "could not reopen FITS file!");
+        UNLOCK_FITS(self);
+        return NULL;
+    } else {
+        if (old_fits != NULL) {
+            istatus = 0;
+            fits_close_file(old_fits, &istatus);
+        }
+        CAPTURE_GIL;
+        UNLOCK_FITS(self);
+        Py_RETURN_NONE;
+    }
+}
+
 static void PyFITSObject_dealloc(struct PyFITSObject *self) {
     ALLOW_NOGIL;
     int status = 0;
@@ -6058,6 +6101,10 @@ static PyMethodDef PyFITSObject_methods[] = {
 
     {"close", (PyCFunction)PyFITSObject_close, METH_VARARGS,
      "close\n\nClose the fits file."},
+
+    {"reopen", (PyCFunction)PyFITSObject_reopen, METH_VARARGS,
+     "reopen\n\nReopen the fits file."},
+
     {NULL} /* Sentinel */
 };
 

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -23,6 +23,7 @@ See the main docs at https://github.com/esheldon/fitsio
 
 from __future__ import with_statement, print_function
 import os
+import threading
 import numpy
 
 from . import _fitsio_wrap
@@ -615,6 +616,7 @@ class FITS(object):
         self.write_bitcols = write_bitcols
         filename = extract_filename(filename)
         self._filename = filename
+        self._lock = threading.RLock()
 
         # self.mode=keys.get('mode','r')
         self.mode = mode
@@ -646,22 +648,24 @@ class FITS(object):
                     create = 1
 
         self._did_create = create == 1
-        self._FITS = _fitsio_wrap.FITS(filename, self.intmode, create)
+        with self._lock:
+            self._FITS = _fitsio_wrap.FITS(filename, self.intmode, create)
 
     def close(self):
         """
         Close the fits file and set relevant metadata to None
         """
-        if hasattr(self, '_FITS'):
-            if self._FITS is not None:
-                self._FITS.close()
-                self._FITS = None
-        self._filename = None
-        self.mode = None
-        self.charmode = None
-        self.intmode = None
-        self.hdu_list = None
-        self.hdu_map = None
+        with self._lock:
+            if hasattr(self, '_FITS'):
+                if self._FITS is not None:
+                    self._FITS.close()
+                    self._FITS = None
+            self._filename = None
+            self.mode = None
+            self.charmode = None
+            self.intmode = None
+            self.hdu_list = None
+            self.hdu_map = None
 
     def movabs_ext(self, ext):
         """
@@ -747,11 +751,12 @@ class FITS(object):
         # in the mem:// file. So we skip the close+reopen cycle for
         # mem:// files. We always update the hdu list and this appears
         # to be important.
-        if not self._filename.startswith("mem://"):
-            self._FITS.close()
-            del self._FITS
-            self._FITS = _fitsio_wrap.FITS(self._filename, self.intmode, 0)
-        self.update_hdu_list()
+        with self._lock:
+            if not self._filename.startswith("mem://"):
+                self._FITS.close()
+                del self._FITS
+                self._FITS = _fitsio_wrap.FITS(self._filename, self.intmode, 0)
+            self.update_hdu_list()
 
     @_doc_string_formatter
     def write(
@@ -1460,30 +1465,33 @@ class FITS(object):
         if rebuild is false or the hdu_list is not yet set, the list is
         rebuilt from scratch
         """
-        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
-            rebuild = True
+        with self._lock:
+            if (not hasattr(self, 'hdu_list')) or (
+                not hasattr(self, "hdu_map")
+            ):
+                rebuild = True
 
-        if rebuild:
-            self.hdu_list = []
-            self.hdu_map = {}
+            if rebuild:
+                self.hdu_list = []
+                self.hdu_map = {}
 
-            # we don't know how many hdus there are, so iterate
-            # until we can't open any more
-            ext_start = 0
-        else:
-            # start from last
-            ext_start = len(self)
+                # we don't know how many hdus there are, so iterate
+                # until we can't open any more
+                ext_start = 0
+            else:
+                # start from last
+                ext_start = len(self)
 
-        ext = ext_start
-        while True:
-            try:
-                self._append_hdu_info(ext)
-            except IOError:
-                break
-            except RuntimeError:
-                break
+            ext = ext_start
+            while True:
+                try:
+                    self._append_hdu_info(ext)
+                except IOError:
+                    break
+                except RuntimeError:
+                    break
 
-            ext = ext + 1
+                ext = ext + 1
 
     def _append_hdu_info(self, ext):
         """

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -912,6 +912,7 @@ class FITS(metaclass=SynchronizedMeta):
         ------------
         The File must be opened READWRITE
         """
+
         self.create_image_hdu(
             img,
             header=header,
@@ -1249,6 +1250,7 @@ class FITS(metaclass=SynchronizedMeta):
         if data.size == 0:
             raise ValueError("data must have at least 1 row")
         """
+
         self.create_table_hdu(
             data=data,
             header=header,

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -34,7 +34,7 @@ from .util import (
     isstring,
     copy_if_needed,
     _nonfinite_as_cfitsio_floating_null_value,
-    SynchronizedMeta,
+    synchronized_class,
 )
 from .header import FITSHDR
 from .hdu import (
@@ -527,7 +527,8 @@ def write(
         )
 
 
-class FITS(metaclass=SynchronizedMeta):
+@synchronized_class
+class FITS:
     """
     A class to read and write FITS images and tables.
 
@@ -598,6 +599,8 @@ class FITS(metaclass=SynchronizedMeta):
         clobber=False,
         **keys,
     ):
+        self._lock = threading.RLock()
+
         if keys:
             import warnings
 
@@ -617,7 +620,6 @@ class FITS(metaclass=SynchronizedMeta):
         self.write_bitcols = write_bitcols
         filename = extract_filename(filename)
         self._filename = filename
-        self._lock = threading.RLock()
 
         # self.mode=keys.get('mode','r')
         self.mode = mode

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -34,6 +34,7 @@ from .util import (
     isstring,
     copy_if_needed,
     _nonfinite_as_cfitsio_floating_null_value,
+    SynchronizedMeta,
 )
 from .header import FITSHDR
 from .hdu import (
@@ -526,7 +527,7 @@ def write(
         )
 
 
-class FITS(object):
+class FITS(metaclass=SynchronizedMeta):
     """
     A class to read and write FITS images and tables.
 
@@ -655,16 +656,15 @@ class FITS(object):
         """
         Close the fits file and set relevant metadata to None
         """
-        with self._lock:
-            if hasattr(self, '_FITS'):
-                self._FITS.close()
-                del self._FITS
-            self._filename = None
-            self.mode = None
-            self.charmode = None
-            self.intmode = None
-            self.hdu_list = None
-            self.hdu_map = None
+        if hasattr(self, '_FITS'):
+            self._FITS.close()
+            del self._FITS
+        self._filename = None
+        self.mode = None
+        self.charmode = None
+        self.intmode = None
+        self.hdu_list = None
+        self.hdu_map = None
 
     def movabs_ext(self, ext):
         """
@@ -684,8 +684,7 @@ class FITS(object):
         format_err = False
 
         try:
-            with self._lock:
-                hdu_type = self._FITS.movabs_hdu(hdunum)
+            hdu_type = self._FITS.movabs_hdu(hdunum)
         except IOError as err:
             # to support python 2 we can't use exception chaining.
             # do this to avoid "During handling of the above exception, another
@@ -710,8 +709,7 @@ class FITS(object):
         returns the zero-offset extension number
         """
         extname = mks(extname)
-        with self._lock:
-            hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
+        hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
         return hdu - 1
 
     def movnam_hdu(self, extname, hdutype=ANY_HDU, extver=0):
@@ -726,8 +724,7 @@ class FITS(object):
 
         extname = mks(extname)
         try:
-            with self._lock:
-                hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
+            hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
         except IOError as err:
             # to support python 2 we can't use exception chaining.
             # do this to avoid "During handling of the above exception, another
@@ -753,10 +750,9 @@ class FITS(object):
         # in the mem:// file. So we skip the close+reopen cycle for
         # mem:// files. We always update the hdu list and this appears
         # to be important.
-        with self._lock:
-            if not self._filename.startswith("mem://"):
-                self._FITS.reopen()
-            self.update_hdu_list()
+        if not self._filename.startswith("mem://"):
+            self._FITS.reopen()
+        self.update_hdu_list()
 
     @_doc_string_formatter
     def write(
@@ -916,23 +912,22 @@ class FITS(object):
         ------------
         The File must be opened READWRITE
         """
-        with self._lock:
-            self.create_image_hdu(
-                img,
-                header=header,
-                extname=extname,
-                extver=extver,
-                compress=compress,
-                tile_dims=tile_dims,
-                qlevel=qlevel,
-                qmethod=qmethod,
-                dither_seed=dither_seed,
-                hcomp_scale=hcomp_scale,
-                hcomp_smooth=hcomp_smooth,
-            )
+        self.create_image_hdu(
+            img,
+            header=header,
+            extname=extname,
+            extver=extver,
+            compress=compress,
+            tile_dims=tile_dims,
+            qlevel=qlevel,
+            qmethod=qmethod,
+            dither_seed=dither_seed,
+            hcomp_scale=hcomp_scale,
+            hcomp_smooth=hcomp_smooth,
+        )
 
-            if header is not None:
-                self[-1].write_keys(header)
+        if header is not None:
+            self[-1].write_keys(header)
 
         # if img is not None:
         #    self[-1].write(img)
@@ -1153,24 +1148,23 @@ class FITS(object):
             img2send, hdu_is_compressed
         ) as img2send_any_nan:
             img2send, any_nan = img2send_any_nan
-            with self._lock:
-                self._FITS.create_image_hdu(
-                    img2send,
-                    nkeys,
-                    dims=dims2send,
-                    comptype=comptype,
-                    tile_dims=tile_dims,
-                    qlevel=qlevel,
-                    qmethod=qmethod,
-                    dither_seed=dither_seed,
-                    hcomp_scale=hcomp_scale,
-                    hcomp_smooth=hcs,
-                    extname=extname,
-                    extver=extver,
-                    any_nan=1 if any_nan else 0,
-                )
+            self._FITS.create_image_hdu(
+                img2send,
+                nkeys,
+                dims=dims2send,
+                comptype=comptype,
+                tile_dims=tile_dims,
+                qlevel=qlevel,
+                qmethod=qmethod,
+                dither_seed=dither_seed,
+                hcomp_scale=hcomp_scale,
+                hcomp_smooth=hcs,
+                extname=extname,
+                extver=extver,
+                any_nan=1 if any_nan else 0,
+            )
 
-                self.update_hdu_list(rebuild=False)
+        self.update_hdu_list(rebuild=False)
 
     def _ensure_empty_image_ok(self):
         """
@@ -1255,29 +1249,27 @@ class FITS(object):
         if data.size == 0:
             raise ValueError("data must have at least 1 row")
         """
-        with self._lock:
-            self.create_table_hdu(
-                data=data,
-                header=header,
-                names=names,
-                units=units,
-                extname=extname,
-                extver=extver,
-                table_type=table_type,
-                write_bitcols=write_bitcols,
-            )
+        self.create_table_hdu(
+            data=data,
+            header=header,
+            names=names,
+            units=units,
+            extname=extname,
+            extver=extver,
+            table_type=table_type,
+            write_bitcols=write_bitcols,
+        )
 
-            if header is not None:
-                self[-1].write_keys(header)
+        if header is not None:
+            self[-1].write_keys(header)
 
-            self[-1].write(data, names=names)
+        self[-1].write(data, names=names)
 
     def read_raw(self):
         """
         Reads the raw FITS file contents, returning a Python string.
         """
-        with self._lock:
-            return self._FITS.read_raw()
+        return self._FITS.read_raw()
 
     def create_table_hdu(
         self,
@@ -1443,21 +1435,20 @@ class FITS(object):
             nkeys = 0
 
         # note we can create extname in the c code for tables, but not images
-        with self._lock:
-            self._FITS.create_table_hdu(
-                table_type_int,
-                nkeys,
-                names,
-                formats,
-                tunit=units,
-                tdim=dims,
-                extname=extname,
-                extver=extver,
-            )
+        self._FITS.create_table_hdu(
+            table_type_int,
+            nkeys,
+            names,
+            formats,
+            tunit=units,
+            tdim=dims,
+            extname=extname,
+            extver=extver,
+        )
 
-            # don't rebuild the whole list unless this is the first hdu
-            # to be created
-            self.update_hdu_list(rebuild=False)
+        # don't rebuild the whole list unless this is the first hdu
+        # to be created
+        self.update_hdu_list(rebuild=False)
 
     def update_hdu_list(self, rebuild=True):
         """
@@ -1468,33 +1459,30 @@ class FITS(object):
         if rebuild is false or the hdu_list is not yet set, the list is
         rebuilt from scratch
         """
-        with self._lock:
-            if (not hasattr(self, 'hdu_list')) or (
-                not hasattr(self, "hdu_map")
-            ):
-                rebuild = True
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
+            rebuild = True
 
-            if rebuild:
-                self.hdu_list = []
-                self.hdu_map = {}
+        if rebuild:
+            self.hdu_list = []
+            self.hdu_map = {}
 
-                # we don't know how many hdus there are, so iterate
-                # until we can't open any more
-                ext_start = 0
-            else:
-                # start from last
-                ext_start = len(self)
+            # we don't know how many hdus there are, so iterate
+            # until we can't open any more
+            ext_start = 0
+        else:
+            # start from last
+            ext_start = len(self)
 
-            ext = ext_start
-            while True:
-                try:
-                    self._append_hdu_info(ext)
-                except IOError:
-                    break
-                except RuntimeError:
-                    break
+        ext = ext_start
+        while True:
+            try:
+                self._append_hdu_info(ext)
+            except IOError:
+                break
+            except RuntimeError:
+                break
 
-                ext = ext + 1
+            ext = ext + 1
 
     def _append_hdu_info(self, ext):
         """
@@ -1560,11 +1548,8 @@ class FITS(object):
         """
         begin iteration over HDUs
         """
-        with self._lock():
-            if (not hasattr(self, 'hdu_list')) or (
-                not hasattr(self, "hdu_map")
-            ):
-                self.update_hdu_list()
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
+            self.update_hdu_list()
         self._iter_index = 0
         return self
 
@@ -1584,12 +1569,9 @@ class FITS(object):
         """
         get the number of extensions
         """
-        with self._lock:
-            if (not hasattr(self, 'hdu_list')) or (
-                not hasattr(self, "hdu_map")
-            ):
-                self.update_hdu_list()
-            return len(self.hdu_list)
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
+            self.update_hdu_list()
+        return len(self.hdu_list)
 
     def _extract_item(self, item):
         """
@@ -1613,49 +1595,44 @@ class FITS(object):
         """
         Get an hdu by number, name, and possibly version
         """
-        with self._lock:
-            if (not hasattr(self, 'hdu_list')) or (
-                not hasattr(self, "hdu_map")
-            ):
-                if self._did_create:
-                    # we created the file and haven't written anything yet
-                    raise ValueError("Requested hdu '%s' not present" % item)
-
-                self.update_hdu_list()
-
-            if len(self) == 0:
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
+            if self._did_create:
+                # we created the file and haven't written anything yet
                 raise ValueError("Requested hdu '%s' not present" % item)
 
-            ext, ver, ver_sent = self._extract_item(item)
+            self.update_hdu_list()
 
-            try:
-                # if it is an int
-                hdu = self.hdu_list[ext]
-            except Exception:
-                # might be a string
-                ext = mks(ext)
-                if not self.case_sensitive:
-                    mess = '(case insensitive)'
-                    ext = ext.lower()
-                else:
-                    mess = '(case sensitive)'
+        if len(self) == 0:
+            raise ValueError("Requested hdu '%s' not present" % item)
 
-                if ver > 0:
-                    key = '%s-%s' % (ext, ver)
-                    if key not in self.hdu_map:
-                        raise IOError(
-                            "extension not found: %s, "
-                            "version %s %s" % (ext, ver, mess)
-                        )
-                    hdu = self.hdu_map[key]
-                else:
-                    if ext not in self.hdu_map:
-                        raise IOError(
-                            "extension not found: %s %s" % (ext, mess)
-                        )
-                    hdu = self.hdu_map[ext]
+        ext, ver, ver_sent = self._extract_item(item)
 
-            return hdu
+        try:
+            # if it is an int
+            hdu = self.hdu_list[ext]
+        except Exception:
+            # might be a string
+            ext = mks(ext)
+            if not self.case_sensitive:
+                mess = '(case insensitive)'
+                ext = ext.lower()
+            else:
+                mess = '(case sensitive)'
+
+            if ver > 0:
+                key = '%s-%s' % (ext, ver)
+                if key not in self.hdu_map:
+                    raise IOError(
+                        "extension not found: %s, "
+                        "version %s %s" % (ext, ver, mess)
+                    )
+                hdu = self.hdu_map[key]
+            else:
+                if ext not in self.hdu_map:
+                    raise IOError("extension not found: %s %s" % (ext, mess))
+                hdu = self.hdu_map[ext]
+
+        return hdu
 
     def __contains__(self, item):
         """
@@ -1679,13 +1656,10 @@ class FITS(object):
 
         rep.append('%sextnum %-15s %s' % (spacing, "hdutype", "hduname[v]"))
 
-        with self._lock:
-            if (not hasattr(self, 'hdu_list')) or (
-                not hasattr(self, "hdu_map")
-            ):
-                if not self._did_create:
-                    # we expect some stuff
-                    self.update_hdu_list()
+        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
+            if not self._did_create:
+                # we expect some stuff
+                self.update_hdu_list()
 
         for i, hdu in enumerate(self.hdu_list):
             t = hdu._info['hdutype']

--- a/fitsio/fitslib.py
+++ b/fitsio/fitslib.py
@@ -657,9 +657,8 @@ class FITS(object):
         """
         with self._lock:
             if hasattr(self, '_FITS'):
-                if self._FITS is not None:
-                    self._FITS.close()
-                    self._FITS = None
+                self._FITS.close()
+                del self._FITS
             self._filename = None
             self.mode = None
             self.charmode = None
@@ -685,7 +684,8 @@ class FITS(object):
         format_err = False
 
         try:
-            hdu_type = self._FITS.movabs_hdu(hdunum)
+            with self._lock:
+                hdu_type = self._FITS.movabs_hdu(hdunum)
         except IOError as err:
             # to support python 2 we can't use exception chaining.
             # do this to avoid "During handling of the above exception, another
@@ -710,7 +710,8 @@ class FITS(object):
         returns the zero-offset extension number
         """
         extname = mks(extname)
-        hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
+        with self._lock:
+            hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
         return hdu - 1
 
     def movnam_hdu(self, extname, hdutype=ANY_HDU, extver=0):
@@ -725,7 +726,8 @@ class FITS(object):
 
         extname = mks(extname)
         try:
-            hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
+            with self._lock:
+                hdu = self._FITS.movnam_hdu(hdutype, extname, extver)
         except IOError as err:
             # to support python 2 we can't use exception chaining.
             # do this to avoid "During handling of the above exception, another
@@ -753,9 +755,7 @@ class FITS(object):
         # to be important.
         with self._lock:
             if not self._filename.startswith("mem://"):
-                self._FITS.close()
-                del self._FITS
-                self._FITS = _fitsio_wrap.FITS(self._filename, self.intmode, 0)
+                self._FITS.reopen()
             self.update_hdu_list()
 
     @_doc_string_formatter
@@ -916,23 +916,23 @@ class FITS(object):
         ------------
         The File must be opened READWRITE
         """
+        with self._lock:
+            self.create_image_hdu(
+                img,
+                header=header,
+                extname=extname,
+                extver=extver,
+                compress=compress,
+                tile_dims=tile_dims,
+                qlevel=qlevel,
+                qmethod=qmethod,
+                dither_seed=dither_seed,
+                hcomp_scale=hcomp_scale,
+                hcomp_smooth=hcomp_smooth,
+            )
 
-        self.create_image_hdu(
-            img,
-            header=header,
-            extname=extname,
-            extver=extver,
-            compress=compress,
-            tile_dims=tile_dims,
-            qlevel=qlevel,
-            qmethod=qmethod,
-            dither_seed=dither_seed,
-            hcomp_scale=hcomp_scale,
-            hcomp_smooth=hcomp_smooth,
-        )
-
-        if header is not None:
-            self[-1].write_keys(header)
+            if header is not None:
+                self[-1].write_keys(header)
 
         # if img is not None:
         #    self[-1].write(img)
@@ -1153,23 +1153,24 @@ class FITS(object):
             img2send, hdu_is_compressed
         ) as img2send_any_nan:
             img2send, any_nan = img2send_any_nan
-            self._FITS.create_image_hdu(
-                img2send,
-                nkeys,
-                dims=dims2send,
-                comptype=comptype,
-                tile_dims=tile_dims,
-                qlevel=qlevel,
-                qmethod=qmethod,
-                dither_seed=dither_seed,
-                hcomp_scale=hcomp_scale,
-                hcomp_smooth=hcs,
-                extname=extname,
-                extver=extver,
-                any_nan=1 if any_nan else 0,
-            )
+            with self._lock:
+                self._FITS.create_image_hdu(
+                    img2send,
+                    nkeys,
+                    dims=dims2send,
+                    comptype=comptype,
+                    tile_dims=tile_dims,
+                    qlevel=qlevel,
+                    qmethod=qmethod,
+                    dither_seed=dither_seed,
+                    hcomp_scale=hcomp_scale,
+                    hcomp_smooth=hcs,
+                    extname=extname,
+                    extver=extver,
+                    any_nan=1 if any_nan else 0,
+                )
 
-        self.update_hdu_list(rebuild=False)
+                self.update_hdu_list(rebuild=False)
 
     def _ensure_empty_image_ok(self):
         """
@@ -1254,28 +1255,29 @@ class FITS(object):
         if data.size == 0:
             raise ValueError("data must have at least 1 row")
         """
+        with self._lock:
+            self.create_table_hdu(
+                data=data,
+                header=header,
+                names=names,
+                units=units,
+                extname=extname,
+                extver=extver,
+                table_type=table_type,
+                write_bitcols=write_bitcols,
+            )
 
-        self.create_table_hdu(
-            data=data,
-            header=header,
-            names=names,
-            units=units,
-            extname=extname,
-            extver=extver,
-            table_type=table_type,
-            write_bitcols=write_bitcols,
-        )
+            if header is not None:
+                self[-1].write_keys(header)
 
-        if header is not None:
-            self[-1].write_keys(header)
-
-        self[-1].write(data, names=names)
+            self[-1].write(data, names=names)
 
     def read_raw(self):
         """
         Reads the raw FITS file contents, returning a Python string.
         """
-        return self._FITS.read_raw()
+        with self._lock:
+            return self._FITS.read_raw()
 
     def create_table_hdu(
         self,
@@ -1441,20 +1443,21 @@ class FITS(object):
             nkeys = 0
 
         # note we can create extname in the c code for tables, but not images
-        self._FITS.create_table_hdu(
-            table_type_int,
-            nkeys,
-            names,
-            formats,
-            tunit=units,
-            tdim=dims,
-            extname=extname,
-            extver=extver,
-        )
+        with self._lock:
+            self._FITS.create_table_hdu(
+                table_type_int,
+                nkeys,
+                names,
+                formats,
+                tunit=units,
+                tdim=dims,
+                extname=extname,
+                extver=extver,
+            )
 
-        # don't rebuild the whole list unless this is the first hdu
-        # to be created
-        self.update_hdu_list(rebuild=False)
+            # don't rebuild the whole list unless this is the first hdu
+            # to be created
+            self.update_hdu_list(rebuild=False)
 
     def update_hdu_list(self, rebuild=True):
         """
@@ -1504,11 +1507,12 @@ class FITS(object):
         hdu_type = self.movabs_ext(ext)
 
         if hdu_type == IMAGE_HDU:
-            hdu = ImageHDU(self._FITS, ext)
+            hdu = ImageHDU(self._FITS, ext, lock=self._lock)
         elif hdu_type == BINARY_TBL:
             hdu = TableHDU(
                 self._FITS,
                 ext,
+                lock=self._lock,
                 lower=self.lower,
                 upper=self.upper,
                 trim_strings=self.trim_strings,
@@ -1521,6 +1525,7 @@ class FITS(object):
             hdu = AsciiTableHDU(
                 self._FITS,
                 ext,
+                lock=self._lock,
                 lower=self.lower,
                 upper=self.upper,
                 trim_strings=self.trim_strings,
@@ -1555,8 +1560,11 @@ class FITS(object):
         """
         begin iteration over HDUs
         """
-        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
-            self.update_hdu_list()
+        with self._lock():
+            if (not hasattr(self, 'hdu_list')) or (
+                not hasattr(self, "hdu_map")
+            ):
+                self.update_hdu_list()
         self._iter_index = 0
         return self
 
@@ -1576,9 +1584,12 @@ class FITS(object):
         """
         get the number of extensions
         """
-        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
-            self.update_hdu_list()
-        return len(self.hdu_list)
+        with self._lock:
+            if (not hasattr(self, 'hdu_list')) or (
+                not hasattr(self, "hdu_map")
+            ):
+                self.update_hdu_list()
+            return len(self.hdu_list)
 
     def _extract_item(self, item):
         """
@@ -1602,44 +1613,49 @@ class FITS(object):
         """
         Get an hdu by number, name, and possibly version
         """
-        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
-            if self._did_create:
-                # we created the file and haven't written anything yet
+        with self._lock:
+            if (not hasattr(self, 'hdu_list')) or (
+                not hasattr(self, "hdu_map")
+            ):
+                if self._did_create:
+                    # we created the file and haven't written anything yet
+                    raise ValueError("Requested hdu '%s' not present" % item)
+
+                self.update_hdu_list()
+
+            if len(self) == 0:
                 raise ValueError("Requested hdu '%s' not present" % item)
 
-            self.update_hdu_list()
+            ext, ver, ver_sent = self._extract_item(item)
 
-        if len(self) == 0:
-            raise ValueError("Requested hdu '%s' not present" % item)
+            try:
+                # if it is an int
+                hdu = self.hdu_list[ext]
+            except Exception:
+                # might be a string
+                ext = mks(ext)
+                if not self.case_sensitive:
+                    mess = '(case insensitive)'
+                    ext = ext.lower()
+                else:
+                    mess = '(case sensitive)'
 
-        ext, ver, ver_sent = self._extract_item(item)
+                if ver > 0:
+                    key = '%s-%s' % (ext, ver)
+                    if key not in self.hdu_map:
+                        raise IOError(
+                            "extension not found: %s, "
+                            "version %s %s" % (ext, ver, mess)
+                        )
+                    hdu = self.hdu_map[key]
+                else:
+                    if ext not in self.hdu_map:
+                        raise IOError(
+                            "extension not found: %s %s" % (ext, mess)
+                        )
+                    hdu = self.hdu_map[ext]
 
-        try:
-            # if it is an int
-            hdu = self.hdu_list[ext]
-        except Exception:
-            # might be a string
-            ext = mks(ext)
-            if not self.case_sensitive:
-                mess = '(case insensitive)'
-                ext = ext.lower()
-            else:
-                mess = '(case sensitive)'
-
-            if ver > 0:
-                key = '%s-%s' % (ext, ver)
-                if key not in self.hdu_map:
-                    raise IOError(
-                        "extension not found: %s, "
-                        "version %s %s" % (ext, ver, mess)
-                    )
-                hdu = self.hdu_map[key]
-            else:
-                if ext not in self.hdu_map:
-                    raise IOError("extension not found: %s %s" % (ext, mess))
-                hdu = self.hdu_map[ext]
-
-        return hdu
+            return hdu
 
     def __contains__(self, item):
         """
@@ -1663,10 +1679,13 @@ class FITS(object):
 
         rep.append('%sextnum %-15s %s' % (spacing, "hdutype", "hduname[v]"))
 
-        if (not hasattr(self, 'hdu_list')) or (not hasattr(self, "hdu_map")):
-            if not self._did_create:
-                # we expect some stuff
-                self.update_hdu_list()
+        with self._lock:
+            if (not hasattr(self, 'hdu_list')) or (
+                not hasattr(self, "hdu_map")
+            ):
+                if not self._did_create:
+                    # we expect some stuff
+                    self.update_hdu_list()
 
         for i, hdu in enumerate(self.hdu_list):
             t = hdu._info['hdutype']

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -342,6 +342,7 @@ class HDUBase(metaclass=SynchronizedMeta):
         Input keys named COMMENT and HISTORY are written using the
         write_comment and write_history methods.
         """
+
         if isinstance(records_in, FITSHDR):
             hdr = records_in
         else:

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -8,7 +8,7 @@ from ..util import (
     _itypes,
     _ftypes,
     FITSRuntimeWarning,
-    SynchronizedMeta,
+    synchronized_class,
 )
 from ..header import FITSHDR
 
@@ -29,7 +29,8 @@ _hdu_type_map = {
 }
 
 
-class HDUBase(metaclass=SynchronizedMeta):
+@synchronized_class
+class HDUBase:
     """
     A representation of a FITS HDU
 
@@ -43,6 +44,7 @@ class HDUBase(metaclass=SynchronizedMeta):
     """
 
     def __init__(self, fits, ext, lock=None, **keys):
+        self._lock = lock or nullcontext()
         if keys:
             import warnings
 
@@ -56,7 +58,6 @@ class HDUBase(metaclass=SynchronizedMeta):
         self._FITS = fits
         self._ext = ext
         self._ignore_scaling = False
-        self._lock = lock or nullcontext()
 
         # init info cache to none
         self._cached_info = None

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -3,7 +3,13 @@ import copy
 import warnings
 from contextlib import nullcontext
 
-from ..util import _stypes, _itypes, _ftypes, FITSRuntimeWarning
+from ..util import (
+    _stypes,
+    _itypes,
+    _ftypes,
+    FITSRuntimeWarning,
+    SynchronizedMeta,
+)
 from ..header import FITSHDR
 
 INVALID_HDR_CHARS_RE = re.compile(r"(\?|\*|#)+")
@@ -23,7 +29,7 @@ _hdu_type_map = {
 }
 
 
-class HDUBase(object):
+class HDUBase(metaclass=SynchronizedMeta):
     """
     A representation of a FITS HDU
 
@@ -53,30 +59,27 @@ class HDUBase(object):
         self._lock = lock or nullcontext()
 
         # init info cache to none
-        with self._lock:
-            self._cached_info = None
-            self._filename = self._FITS.filename()
+        self._cached_info = None
+        self._filename = self._FITS.filename()
 
     @property
     def _info(self):
-        with self._lock:
-            if self._cached_info is None:
-                self._update_info()
-            return self._cached_info
+        if self._cached_info is None:
+            self._update_info()
+        return self._cached_info
 
     def _update_info(self):
         """
         Update metadata for this HDU
         """
-        with self._lock:
-            try:
-                self._FITS.movabs_hdu(self._ext + 1)
-            except IOError:
-                raise RuntimeError("no such hdu")
+        try:
+            self._FITS.movabs_hdu(self._ext + 1)
+        except IOError:
+            raise RuntimeError("no such hdu")
 
-            self._cached_info = self._FITS.get_hdu_info(
-                self._ext + 1, self._ignore_scaling
-            )
+        self._cached_info = self._FITS.get_hdu_info(
+            self._ext + 1, self._ignore_scaling
+        )
 
     @property
     def ignore_scaling(self):
@@ -91,14 +94,13 @@ class HDUBase(object):
         """
         Set the flag to ignore scaling.
         """
-        with self._lock:
-            old_val = self._ignore_scaling
-            self._ignore_scaling = ignore_scaling_flag
+        old_val = self._ignore_scaling
+        self._ignore_scaling = ignore_scaling_flag
 
-            # if needed invalidate the info cache so it gets
-            # updated the next time we access it
-            if old_val != self._ignore_scaling:
-                self._cached_info = None
+        # if needed invalidate the info cache so it gets
+        # updated the next time we access it
+        if old_val != self._ignore_scaling:
+            self._cached_info = None
 
     def get_extnum(self):
         """
@@ -198,17 +200,15 @@ class HDUBase(object):
         -------
         A dict with keys 'datasum' and 'hdusum'
         """
-        with self._lock:
-            ret = self._FITS.write_checksum(self._ext + 1)
-            self._cached_info = None  # invalidate info cache
+        ret = self._FITS.write_checksum(self._ext + 1)
+        self._cached_info = None  # invalidate info cache
         return ret
 
     def verify_checksum(self):
         """
         Verify the checksum in the header for this HDU.
         """
-        with self._lock:
-            res = self._FITS.verify_checksum(self._ext + 1)
+        res = self._FITS.verify_checksum(self._ext + 1)
         if res['dataok'] != 1:
             raise ValueError("data checksum failed")
         if res['hduok'] != 1:
@@ -218,25 +218,22 @@ class HDUBase(object):
         """
         Write a comment into the header
         """
-        with self._lock:
-            self._FITS.write_comment(self._ext + 1, str(comment))
-            self._cached_info = None  # invalidate info cache
+        self._FITS.write_comment(self._ext + 1, str(comment))
+        self._cached_info = None  # invalidate info cache
 
     def write_history(self, history):
         """
         Write history text into the header
         """
-        with self._lock:
-            self._FITS.write_history(self._ext + 1, str(history))
-            self._cached_info = None  # invalidate info cache
+        self._FITS.write_history(self._ext + 1, str(history))
+        self._cached_info = None  # invalidate info cache
 
     def _write_continue(self, value):
         """
         Write history text into the header
         """
-        with self._lock:
-            self._FITS.write_continue(self._ext + 1, str(value))
-            self._cached_info = None  # invalidate info cache
+        self._FITS.write_continue(self._ext + 1, str(value))
+        self._cached_info = None  # invalidate info cache
 
     def write_key(self, name, value, comment=""):
         """
@@ -258,71 +255,68 @@ class HDUBase(object):
         methods
         """
 
-        with self._lock:
-            if name is None:
-                # we write a blank keyword and the rest is a comment
-                # string
+        if name is None:
+            # we write a blank keyword and the rest is a comment
+            # string
 
-                if not isinstance(comment, _stypes):
-                    raise ValueError(
-                        'when writing blank key the value must be a string'
-                    )
-
-                # this might be longer than 80 but that's ok, the routine
-                # will take care of it
-                # card = '         ' + str(comment)
-                card = '        ' + str(comment)
-                self._FITS.write_record(
-                    self._ext + 1,
-                    card,
+            if not isinstance(comment, _stypes):
+                raise ValueError(
+                    'when writing blank key the value must be a string'
                 )
 
-            elif value is None:
-                self._FITS.write_undefined_key(
-                    self._ext + 1, str(name), str(comment)
-                )
+            # this might be longer than 80 but that's ok, the routine
+            # will take care of it
+            # card = '         ' + str(comment)
+            card = '        ' + str(comment)
+            self._FITS.write_record(
+                self._ext + 1,
+                card,
+            )
 
-            elif isinstance(value, bool):
-                if value:
-                    v = 1
-                else:
-                    v = 0
-                self._FITS.write_logical_key(
-                    self._ext + 1, str(name), v, str(comment)
-                )
-            elif isinstance(value, _stypes):
-                self._FITS.write_string_key(
-                    self._ext + 1, str(name), str(value), str(comment)
-                )
-            elif isinstance(value, _ftypes):
-                self._FITS.write_double_key(
-                    self._ext + 1, str(name), float(value), str(comment)
-                )
-            elif isinstance(value, _itypes):
-                self._FITS.write_long_long_key(
-                    self._ext + 1, str(name), int(value), str(comment)
-                )
-            elif isinstance(value, (tuple, list)):
-                vl = [str(el) for el in value]
-                sval = ','.join(vl)
-                self._FITS.write_string_key(
-                    self._ext + 1, str(name), sval, str(comment)
-                )
+        elif value is None:
+            self._FITS.write_undefined_key(
+                self._ext + 1, str(name), str(comment)
+            )
+
+        elif isinstance(value, bool):
+            if value:
+                v = 1
             else:
-                sval = str(value)
-                mess = (
-                    "warning, keyword '%s' has non-standard "
-                    "value type %s, "
-                    "Converting to string: '%s'"
-                )
-                warnings.warn(
-                    mess % (name, type(value), sval), FITSRuntimeWarning
-                )
-                self._FITS.write_string_key(
-                    self._ext + 1, str(name), sval, str(comment)
-                )
+                v = 0
+            self._FITS.write_logical_key(
+                self._ext + 1, str(name), v, str(comment)
+            )
+        elif isinstance(value, _stypes):
+            self._FITS.write_string_key(
+                self._ext + 1, str(name), str(value), str(comment)
+            )
+        elif isinstance(value, _ftypes):
+            self._FITS.write_double_key(
+                self._ext + 1, str(name), float(value), str(comment)
+            )
+        elif isinstance(value, _itypes):
+            self._FITS.write_long_long_key(
+                self._ext + 1, str(name), int(value), str(comment)
+            )
+        elif isinstance(value, (tuple, list)):
+            vl = [str(el) for el in value]
+            sval = ','.join(vl)
+            self._FITS.write_string_key(
+                self._ext + 1, str(name), sval, str(comment)
+            )
+        else:
+            sval = str(value)
+            mess = (
+                "warning, keyword '%s' has non-standard "
+                "value type %s, "
+                "Converting to string: '%s'"
+            )
+            warnings.warn(mess % (name, type(value), sval), FITSRuntimeWarning)
+            self._FITS.write_string_key(
+                self._ext + 1, str(name), sval, str(comment)
+            )
 
-            self._cached_info = None  # invalidate info cache
+        self._cached_info = None  # invalidate info cache
 
     def write_keys(self, records_in, clean=True):
         """
@@ -348,42 +342,41 @@ class HDUBase(object):
         Input keys named COMMENT and HISTORY are written using the
         write_comment and write_history methods.
         """
-        with self._lock:
-            if isinstance(records_in, FITSHDR):
-                hdr = records_in
+        if isinstance(records_in, FITSHDR):
+            hdr = records_in
+        else:
+            hdr = FITSHDR(records_in)
+
+        if clean:
+            is_table = hasattr(self, '_table_type_str')
+            # is_table = isinstance(self, TableHDU)
+            hdr.clean(is_table=is_table)
+
+        for r in hdr.records():
+            name = r['name']
+            if name is not None:
+                name = name.upper()
+
+                if INVALID_HDR_CHARS_RE.search(name):
+                    raise RuntimeError(
+                        "header key '%s' has invalid characters! "
+                        "Characters in %s are not allowed!"
+                        % (name, INVALID_HDR_CHARS)
+                    )
+
+            value = r['value']
+
+            if name == 'COMMENT':
+                self.write_comment(value)
+            elif name == 'HISTORY':
+                self.write_history(value)
+            elif name == 'CONTINUE':
+                self._write_continue(value)
             else:
-                hdr = FITSHDR(records_in)
+                comment = r.get('comment', '')
+                self.write_key(name, value, comment=comment)
 
-            if clean:
-                is_table = hasattr(self, '_table_type_str')
-                # is_table = isinstance(self, TableHDU)
-                hdr.clean(is_table=is_table)
-
-            for r in hdr.records():
-                name = r['name']
-                if name is not None:
-                    name = name.upper()
-
-                    if INVALID_HDR_CHARS_RE.search(name):
-                        raise RuntimeError(
-                            "header key '%s' has invalid characters! "
-                            "Characters in %s are not allowed!"
-                            % (name, INVALID_HDR_CHARS)
-                        )
-
-                value = r['value']
-
-                if name == 'COMMENT':
-                    self.write_comment(value)
-                elif name == 'HISTORY':
-                    self.write_history(value)
-                elif name == 'CONTINUE':
-                    self._write_continue(value)
-                else:
-                    comment = r.get('comment', '')
-                    self.write_key(name, value, comment=comment)
-
-            self._cached_info = None  # invalidate info cache
+        self._cached_info = None  # invalidate info cache
 
     def read_header(self):
         """
@@ -408,8 +401,7 @@ class HDUBase(object):
             'value': the value field as a string
             'comment': the comment field as a string.
         """
-        with self._lock:
-            return self._FITS.read_header(self._ext + 1)
+        return self._FITS.read_header(self._ext + 1)
 
     def delete_key(self, name):
         """
@@ -431,10 +423,9 @@ class HDUBase(object):
         names: iterable of keys
             Names of keywords to delete.
         """
-        with self._lock:
-            for name in names:
-                self._FITS.delete_key(self._ext + 1, str(name))
-            self._cached_info = None  # invalidate info cache
+        for name in names:
+            self._FITS.delete_key(self._ext + 1, str(name))
+        self._cached_info = None  # invalidate info cache
 
     def _get_repr_list(self):
         """

--- a/fitsio/hdu/base.py
+++ b/fitsio/hdu/base.py
@@ -1,6 +1,7 @@
 import re
 import copy
 import warnings
+from contextlib import nullcontext
 
 from ..util import _stypes, _itypes, _ftypes, FITSRuntimeWarning
 from ..header import FITSHDR
@@ -35,7 +36,7 @@ class HDUBase(object):
         The extension number.
     """
 
-    def __init__(self, fits, ext, **keys):
+    def __init__(self, fits, ext, lock=None, **keys):
         if keys:
             import warnings
 
@@ -49,29 +50,33 @@ class HDUBase(object):
         self._FITS = fits
         self._ext = ext
         self._ignore_scaling = False
+        self._lock = lock or nullcontext()
 
         # init info cache to none
-        self._cached_info = None
-        self._filename = self._FITS.filename()
+        with self._lock:
+            self._cached_info = None
+            self._filename = self._FITS.filename()
 
     @property
     def _info(self):
-        if self._cached_info is None:
-            self._update_info()
-        return self._cached_info
+        with self._lock:
+            if self._cached_info is None:
+                self._update_info()
+            return self._cached_info
 
     def _update_info(self):
         """
         Update metadata for this HDU
         """
-        try:
-            self._FITS.movabs_hdu(self._ext + 1)
-        except IOError:
-            raise RuntimeError("no such hdu")
+        with self._lock:
+            try:
+                self._FITS.movabs_hdu(self._ext + 1)
+            except IOError:
+                raise RuntimeError("no such hdu")
 
-        self._cached_info = self._FITS.get_hdu_info(
-            self._ext + 1, self._ignore_scaling
-        )
+            self._cached_info = self._FITS.get_hdu_info(
+                self._ext + 1, self._ignore_scaling
+            )
 
     @property
     def ignore_scaling(self):
@@ -86,13 +91,14 @@ class HDUBase(object):
         """
         Set the flag to ignore scaling.
         """
-        old_val = self._ignore_scaling
-        self._ignore_scaling = ignore_scaling_flag
+        with self._lock:
+            old_val = self._ignore_scaling
+            self._ignore_scaling = ignore_scaling_flag
 
-        # if needed invalidate the info cache so it gets
-        # updated the next time we access it
-        if old_val != self._ignore_scaling:
-            self._cached_info = None
+            # if needed invalidate the info cache so it gets
+            # updated the next time we access it
+            if old_val != self._ignore_scaling:
+                self._cached_info = None
 
     def get_extnum(self):
         """
@@ -192,15 +198,17 @@ class HDUBase(object):
         -------
         A dict with keys 'datasum' and 'hdusum'
         """
-        ret = self._FITS.write_checksum(self._ext + 1)
-        self._cached_info = None  # invalidate info cache
+        with self._lock:
+            ret = self._FITS.write_checksum(self._ext + 1)
+            self._cached_info = None  # invalidate info cache
         return ret
 
     def verify_checksum(self):
         """
         Verify the checksum in the header for this HDU.
         """
-        res = self._FITS.verify_checksum(self._ext + 1)
+        with self._lock:
+            res = self._FITS.verify_checksum(self._ext + 1)
         if res['dataok'] != 1:
             raise ValueError("data checksum failed")
         if res['hduok'] != 1:
@@ -210,22 +218,25 @@ class HDUBase(object):
         """
         Write a comment into the header
         """
-        self._FITS.write_comment(self._ext + 1, str(comment))
-        self._cached_info = None  # invalidate info cache
+        with self._lock:
+            self._FITS.write_comment(self._ext + 1, str(comment))
+            self._cached_info = None  # invalidate info cache
 
     def write_history(self, history):
         """
         Write history text into the header
         """
-        self._FITS.write_history(self._ext + 1, str(history))
-        self._cached_info = None  # invalidate info cache
+        with self._lock:
+            self._FITS.write_history(self._ext + 1, str(history))
+            self._cached_info = None  # invalidate info cache
 
     def _write_continue(self, value):
         """
         Write history text into the header
         """
-        self._FITS.write_continue(self._ext + 1, str(value))
-        self._cached_info = None  # invalidate info cache
+        with self._lock:
+            self._FITS.write_continue(self._ext + 1, str(value))
+            self._cached_info = None  # invalidate info cache
 
     def write_key(self, name, value, comment=""):
         """
@@ -247,68 +258,71 @@ class HDUBase(object):
         methods
         """
 
-        if name is None:
-            # we write a blank keyword and the rest is a comment
-            # string
+        with self._lock:
+            if name is None:
+                # we write a blank keyword and the rest is a comment
+                # string
 
-            if not isinstance(comment, _stypes):
-                raise ValueError(
-                    'when writing blank key the value must be a string'
+                if not isinstance(comment, _stypes):
+                    raise ValueError(
+                        'when writing blank key the value must be a string'
+                    )
+
+                # this might be longer than 80 but that's ok, the routine
+                # will take care of it
+                # card = '         ' + str(comment)
+                card = '        ' + str(comment)
+                self._FITS.write_record(
+                    self._ext + 1,
+                    card,
                 )
 
-            # this might be longer than 80 but that's ok, the routine
-            # will take care of it
-            # card = '         ' + str(comment)
-            card = '        ' + str(comment)
-            self._FITS.write_record(
-                self._ext + 1,
-                card,
-            )
+            elif value is None:
+                self._FITS.write_undefined_key(
+                    self._ext + 1, str(name), str(comment)
+                )
 
-        elif value is None:
-            self._FITS.write_undefined_key(
-                self._ext + 1, str(name), str(comment)
-            )
-
-        elif isinstance(value, bool):
-            if value:
-                v = 1
+            elif isinstance(value, bool):
+                if value:
+                    v = 1
+                else:
+                    v = 0
+                self._FITS.write_logical_key(
+                    self._ext + 1, str(name), v, str(comment)
+                )
+            elif isinstance(value, _stypes):
+                self._FITS.write_string_key(
+                    self._ext + 1, str(name), str(value), str(comment)
+                )
+            elif isinstance(value, _ftypes):
+                self._FITS.write_double_key(
+                    self._ext + 1, str(name), float(value), str(comment)
+                )
+            elif isinstance(value, _itypes):
+                self._FITS.write_long_long_key(
+                    self._ext + 1, str(name), int(value), str(comment)
+                )
+            elif isinstance(value, (tuple, list)):
+                vl = [str(el) for el in value]
+                sval = ','.join(vl)
+                self._FITS.write_string_key(
+                    self._ext + 1, str(name), sval, str(comment)
+                )
             else:
-                v = 0
-            self._FITS.write_logical_key(
-                self._ext + 1, str(name), v, str(comment)
-            )
-        elif isinstance(value, _stypes):
-            self._FITS.write_string_key(
-                self._ext + 1, str(name), str(value), str(comment)
-            )
-        elif isinstance(value, _ftypes):
-            self._FITS.write_double_key(
-                self._ext + 1, str(name), float(value), str(comment)
-            )
-        elif isinstance(value, _itypes):
-            self._FITS.write_long_long_key(
-                self._ext + 1, str(name), int(value), str(comment)
-            )
-        elif isinstance(value, (tuple, list)):
-            vl = [str(el) for el in value]
-            sval = ','.join(vl)
-            self._FITS.write_string_key(
-                self._ext + 1, str(name), sval, str(comment)
-            )
-        else:
-            sval = str(value)
-            mess = (
-                "warning, keyword '%s' has non-standard "
-                "value type %s, "
-                "Converting to string: '%s'"
-            )
-            warnings.warn(mess % (name, type(value), sval), FITSRuntimeWarning)
-            self._FITS.write_string_key(
-                self._ext + 1, str(name), sval, str(comment)
-            )
+                sval = str(value)
+                mess = (
+                    "warning, keyword '%s' has non-standard "
+                    "value type %s, "
+                    "Converting to string: '%s'"
+                )
+                warnings.warn(
+                    mess % (name, type(value), sval), FITSRuntimeWarning
+                )
+                self._FITS.write_string_key(
+                    self._ext + 1, str(name), sval, str(comment)
+                )
 
-        self._cached_info = None  # invalidate info cache
+            self._cached_info = None  # invalidate info cache
 
     def write_keys(self, records_in, clean=True):
         """
@@ -334,42 +348,42 @@ class HDUBase(object):
         Input keys named COMMENT and HISTORY are written using the
         write_comment and write_history methods.
         """
-
-        if isinstance(records_in, FITSHDR):
-            hdr = records_in
-        else:
-            hdr = FITSHDR(records_in)
-
-        if clean:
-            is_table = hasattr(self, '_table_type_str')
-            # is_table = isinstance(self, TableHDU)
-            hdr.clean(is_table=is_table)
-
-        for r in hdr.records():
-            name = r['name']
-            if name is not None:
-                name = name.upper()
-
-                if INVALID_HDR_CHARS_RE.search(name):
-                    raise RuntimeError(
-                        "header key '%s' has invalid characters! "
-                        "Characters in %s are not allowed!"
-                        % (name, INVALID_HDR_CHARS)
-                    )
-
-            value = r['value']
-
-            if name == 'COMMENT':
-                self.write_comment(value)
-            elif name == 'HISTORY':
-                self.write_history(value)
-            elif name == 'CONTINUE':
-                self._write_continue(value)
+        with self._lock:
+            if isinstance(records_in, FITSHDR):
+                hdr = records_in
             else:
-                comment = r.get('comment', '')
-                self.write_key(name, value, comment=comment)
+                hdr = FITSHDR(records_in)
 
-        self._cached_info = None  # invalidate info cache
+            if clean:
+                is_table = hasattr(self, '_table_type_str')
+                # is_table = isinstance(self, TableHDU)
+                hdr.clean(is_table=is_table)
+
+            for r in hdr.records():
+                name = r['name']
+                if name is not None:
+                    name = name.upper()
+
+                    if INVALID_HDR_CHARS_RE.search(name):
+                        raise RuntimeError(
+                            "header key '%s' has invalid characters! "
+                            "Characters in %s are not allowed!"
+                            % (name, INVALID_HDR_CHARS)
+                        )
+
+                value = r['value']
+
+                if name == 'COMMENT':
+                    self.write_comment(value)
+                elif name == 'HISTORY':
+                    self.write_history(value)
+                elif name == 'CONTINUE':
+                    self._write_continue(value)
+                else:
+                    comment = r.get('comment', '')
+                    self.write_key(name, value, comment=comment)
+
+            self._cached_info = None  # invalidate info cache
 
     def read_header(self):
         """
@@ -394,7 +408,8 @@ class HDUBase(object):
             'value': the value field as a string
             'comment': the comment field as a string.
         """
-        return self._FITS.read_header(self._ext + 1)
+        with self._lock:
+            return self._FITS.read_header(self._ext + 1)
 
     def delete_key(self, name):
         """
@@ -416,9 +431,10 @@ class HDUBase(object):
         names: iterable of keys
             Names of keywords to delete.
         """
-        for name in names:
-            self._FITS.delete_key(self._ext + 1, str(name))
-        self._cached_info = None  # invalidate info cache
+        with self._lock:
+            for name in names:
+                self._FITS.delete_key(self._ext + 1, str(name))
+            self._cached_info = None  # invalidate info cache
 
     def _get_repr_list(self):
         """

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -213,8 +213,7 @@ class ImageHDU(HDUBase):
                     )
 
                     # we have to reverse the dimensions here since cfitsio
-                    # uses fortran order and offset by 1 for fortan
-                    # indexing
+                    # uses fortran order and offset by 1 for fortan indexing
                     firstpixel = firstpixel[::-1] + 1
                     lastpixel = lastpixel[::-1] + 1
 
@@ -255,8 +254,7 @@ class ImageHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being "
-                "ignored! This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -415,10 +413,9 @@ class ImageHDU(HDUBase):
         steps = numpy.array(steps, dtype='i8')
 
         array = numpy.zeros(arrdims, dtype=npy_dtype)
-        with self._lock:
-            self._FITS.read_image_slice(
-                self._ext + 1, first, last, steps, self._ignore_scaling, array
-            )
+        self._FITS.read_image_slice(
+            self._ext + 1, first, last, steps, self._ignore_scaling, array
+        )
         return array
 
     def _expand_if_needed(self, dims, write_dims, start):

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -45,15 +45,16 @@ class ImageHDU(HDUBase):
         Call parent method and make sure this is in fact a
         image HDU.  Set dims in C order
         """
-        super(ImageHDU, self)._update_info()
+        with self._lock:
+            super(ImageHDU, self)._update_info()
 
-        if self._info['hdutype'] != IMAGE_HDU:
-            mess = "Extension %s is not a Image HDU" % self.ext
-            raise ValueError(mess)
+            if self._info['hdutype'] != IMAGE_HDU:
+                mess = "Extension %s is not a Image HDU" % self.ext
+                raise ValueError(mess)
 
-        # convert to c order
-        if 'dims' in self._info:
-            self._info['dims'] = list(reversed(self._info['dims']))
+            # convert to c order
+            if 'dims' in self._info:
+                self._info['dims'] = list(reversed(self._info['dims']))
 
     def has_data(self):
         """
@@ -120,8 +121,9 @@ class ImageHDU(HDUBase):
         adims = numpy.array(dims, ndmin=1, dtype='i8')
         # we have to reverse the dimensions here since cfitsio
         # uses fortran order
-        self._FITS.reshape_image(self._ext + 1, adims[::-1])
-        self._cached_info = None  # invalidate info cache
+        with self._lock:
+            self._FITS.reshape_image(self._ext + 1, adims[::-1])
+            self._cached_info = None  # invalidate info cache
 
     def write(self, img, start=0, **keys):
         """
@@ -189,59 +191,63 @@ class ImageHDU(HDUBase):
         else:
             write_subset = False
 
-        with _nonfinite_as_cfitsio_floating_null_value(
-            img_send, self.is_compressed()
-        ) as img_send_any_nan:
-            img_send, any_nan = img_send_any_nan
-            if not write_subset:
-                # write in image at start in a single pass
-                offset = 0
-                self._FITS.write_image(
-                    self._ext + 1,
-                    img_send,
-                    offset + 1,
-                    1 if any_nan else 0,
-                )
-            else:
-                if not any_nan and not self.is_compressed():
-                    firstpixel = numpy.array(start, ndmin=1, dtype='i8')
-                    # lastpixel is the index of the lastpixel so subtract 1
-                    lastpixel = (
-                        firstpixel
-                        + numpy.array(img_send.shape, ndmin=1, dtype='i8')
-                        - 1
-                    )
-
-                    # we have to reverse the dimensions here since cfitsio
-                    # uses fortran order and offset by 1 for fortan indexing
-                    firstpixel = firstpixel[::-1] + 1
-                    lastpixel = lastpixel[::-1] + 1
-
-                    self._FITS.write_subset(
-                        self._ext + 1, img_send, firstpixel, lastpixel
+        with self._lock:
+            with _nonfinite_as_cfitsio_floating_null_value(
+                img_send, self.is_compressed()
+            ) as img_send_any_nan:
+                img_send, any_nan = img_send_any_nan
+                if not write_subset:
+                    # write in image at start in a single pass
+                    offset = 0
+                    self._FITS.write_image(
+                        self._ext + 1,
+                        img_send,
+                        offset + 1,
+                        1 if any_nan else 0,
                     )
                 else:
-                    # the C API doesn't support nan handling w/ rectangular
-                    # subsets, so emulate in python
-                    # go "row by row" but in more than two dimensions
-                    ndims = len(dims)
-                    for index in numpy.ndindex(*(img_send.shape[:-1])):
-                        new_start = [
-                            start[i] + index[i] for i in range(ndims - 1)
-                        ]
-                        new_start += [start[-1]]
-                        offset = _convert_full_start_to_offset(dims, new_start)
-                        img_slice = tuple(
-                            [slice(ns, ns + 1) for ns in index]
-                        ) + (slice(None),)
-                        self._FITS.write_image(
-                            self._ext + 1,
-                            img_send[img_slice],
-                            offset + 1,
-                            1 if any_nan else 0,
+                    if not any_nan and not self.is_compressed():
+                        firstpixel = numpy.array(start, ndmin=1, dtype='i8')
+                        # lastpixel is the index of the lastpixel so subtract 1
+                        lastpixel = (
+                            firstpixel
+                            + numpy.array(img_send.shape, ndmin=1, dtype='i8')
+                            - 1
                         )
 
-        self._cached_info = None  # invalidate info cache
+                        # we have to reverse the dimensions here since cfitsio
+                        # uses fortran order and offset by 1 for fortan
+                        # indexing
+                        firstpixel = firstpixel[::-1] + 1
+                        lastpixel = lastpixel[::-1] + 1
+
+                        self._FITS.write_subset(
+                            self._ext + 1, img_send, firstpixel, lastpixel
+                        )
+                    else:
+                        # the C API doesn't support nan handling w/ rectangular
+                        # subsets, so emulate in python
+                        # go "row by row" but in more than two dimensions
+                        ndims = len(dims)
+                        for index in numpy.ndindex(*(img_send.shape[:-1])):
+                            new_start = [
+                                start[i] + index[i] for i in range(ndims - 1)
+                            ]
+                            new_start += [start[-1]]
+                            offset = _convert_full_start_to_offset(
+                                dims, new_start
+                            )
+                            img_slice = tuple(
+                                [slice(ns, ns + 1) for ns in index]
+                            ) + (slice(None),)
+                            self._FITS.write_image(
+                                self._ext + 1,
+                                img_send[img_slice],
+                                offset + 1,
+                                1 if any_nan else 0,
+                            )
+
+            self._cached_info = None  # invalidate info cache
 
     def read(self, **keys):
         """
@@ -250,24 +256,25 @@ class ImageHDU(HDUBase):
         If the HDU is an IMAGE_HDU, read the corresponding image.  Compression
         and scaling are dealt with properly.
         """
+        with self._lock:
+            if keys:
+                import warnings
 
-        if keys:
-            import warnings
+                warnings.warn(
+                    "The keyword arguments '%s' are being "
+                    "ignored! This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            if not self.has_data():
+                return None
 
-        if not self.has_data():
-            return None
-
-        dtype, shape = self._get_dtype_and_shape()
-        array = numpy.zeros(shape, dtype=dtype)
-        self._FITS.read_image(self._ext + 1, array)
-        return array
+            dtype, shape = self._get_dtype_and_shape()
+            array = numpy.zeros(shape, dtype=dtype)
+            self._FITS.read_image(self._ext + 1, array)
+            return array
 
     def _get_dtype_and_shape(self):
         """
@@ -414,9 +421,10 @@ class ImageHDU(HDUBase):
         steps = numpy.array(steps, dtype='i8')
 
         array = numpy.zeros(arrdims, dtype=npy_dtype)
-        self._FITS.read_image_slice(
-            self._ext + 1, first, last, steps, self._ignore_scaling, array
-        )
+        with self._lock:
+            self._FITS.read_image_slice(
+                self._ext + 1, first, last, steps, self._ignore_scaling, array
+            )
         return array
 
     def _expand_if_needed(self, dims, write_dims, start):

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -45,16 +45,15 @@ class ImageHDU(HDUBase):
         Call parent method and make sure this is in fact a
         image HDU.  Set dims in C order
         """
-        with self._lock:
-            super(ImageHDU, self)._update_info()
+        super(ImageHDU, self)._update_info()
 
-            if self._info['hdutype'] != IMAGE_HDU:
-                mess = "Extension %s is not a Image HDU" % self.ext
-                raise ValueError(mess)
+        if self._info['hdutype'] != IMAGE_HDU:
+            mess = "Extension %s is not a Image HDU" % self.ext
+            raise ValueError(mess)
 
-            # convert to c order
-            if 'dims' in self._info:
-                self._info['dims'] = list(reversed(self._info['dims']))
+        # convert to c order
+        if 'dims' in self._info:
+            self._info['dims'] = list(reversed(self._info['dims']))
 
     def has_data(self):
         """
@@ -121,9 +120,8 @@ class ImageHDU(HDUBase):
         adims = numpy.array(dims, ndmin=1, dtype='i8')
         # we have to reverse the dimensions here since cfitsio
         # uses fortran order
-        with self._lock:
-            self._FITS.reshape_image(self._ext + 1, adims[::-1])
-            self._cached_info = None  # invalidate info cache
+        self._FITS.reshape_image(self._ext + 1, adims[::-1])
+        self._cached_info = None  # invalidate info cache
 
     def write(self, img, start=0, **keys):
         """
@@ -191,63 +189,60 @@ class ImageHDU(HDUBase):
         else:
             write_subset = False
 
-        with self._lock:
-            with _nonfinite_as_cfitsio_floating_null_value(
-                img_send, self.is_compressed()
-            ) as img_send_any_nan:
-                img_send, any_nan = img_send_any_nan
-                if not write_subset:
-                    # write in image at start in a single pass
-                    offset = 0
-                    self._FITS.write_image(
-                        self._ext + 1,
-                        img_send,
-                        offset + 1,
-                        1 if any_nan else 0,
+        with _nonfinite_as_cfitsio_floating_null_value(
+            img_send, self.is_compressed()
+        ) as img_send_any_nan:
+            img_send, any_nan = img_send_any_nan
+            if not write_subset:
+                # write in image at start in a single pass
+                offset = 0
+                self._FITS.write_image(
+                    self._ext + 1,
+                    img_send,
+                    offset + 1,
+                    1 if any_nan else 0,
+                )
+            else:
+                if not any_nan and not self.is_compressed():
+                    firstpixel = numpy.array(start, ndmin=1, dtype='i8')
+                    # lastpixel is the index of the lastpixel so subtract 1
+                    lastpixel = (
+                        firstpixel
+                        + numpy.array(img_send.shape, ndmin=1, dtype='i8')
+                        - 1
+                    )
+
+                    # we have to reverse the dimensions here since cfitsio
+                    # uses fortran order and offset by 1 for fortan
+                    # indexing
+                    firstpixel = firstpixel[::-1] + 1
+                    lastpixel = lastpixel[::-1] + 1
+
+                    self._FITS.write_subset(
+                        self._ext + 1, img_send, firstpixel, lastpixel
                     )
                 else:
-                    if not any_nan and not self.is_compressed():
-                        firstpixel = numpy.array(start, ndmin=1, dtype='i8')
-                        # lastpixel is the index of the lastpixel so subtract 1
-                        lastpixel = (
-                            firstpixel
-                            + numpy.array(img_send.shape, ndmin=1, dtype='i8')
-                            - 1
+                    # the C API doesn't support nan handling w/ rectangular
+                    # subsets, so emulate in python
+                    # go "row by row" but in more than two dimensions
+                    ndims = len(dims)
+                    for index in numpy.ndindex(*(img_send.shape[:-1])):
+                        new_start = [
+                            start[i] + index[i] for i in range(ndims - 1)
+                        ]
+                        new_start += [start[-1]]
+                        offset = _convert_full_start_to_offset(dims, new_start)
+                        img_slice = tuple(
+                            [slice(ns, ns + 1) for ns in index]
+                        ) + (slice(None),)
+                        self._FITS.write_image(
+                            self._ext + 1,
+                            img_send[img_slice],
+                            offset + 1,
+                            1 if any_nan else 0,
                         )
 
-                        # we have to reverse the dimensions here since cfitsio
-                        # uses fortran order and offset by 1 for fortan
-                        # indexing
-                        firstpixel = firstpixel[::-1] + 1
-                        lastpixel = lastpixel[::-1] + 1
-
-                        self._FITS.write_subset(
-                            self._ext + 1, img_send, firstpixel, lastpixel
-                        )
-                    else:
-                        # the C API doesn't support nan handling w/ rectangular
-                        # subsets, so emulate in python
-                        # go "row by row" but in more than two dimensions
-                        ndims = len(dims)
-                        for index in numpy.ndindex(*(img_send.shape[:-1])):
-                            new_start = [
-                                start[i] + index[i] for i in range(ndims - 1)
-                            ]
-                            new_start += [start[-1]]
-                            offset = _convert_full_start_to_offset(
-                                dims, new_start
-                            )
-                            img_slice = tuple(
-                                [slice(ns, ns + 1) for ns in index]
-                            ) + (slice(None),)
-                            self._FITS.write_image(
-                                self._ext + 1,
-                                img_send[img_slice],
-                                offset + 1,
-                                1 if any_nan else 0,
-                            )
-
-            self._cached_info = None  # invalidate info cache
+        self._cached_info = None  # invalidate info cache
 
     def read(self, **keys):
         """
@@ -256,25 +251,24 @@ class ImageHDU(HDUBase):
         If the HDU is an IMAGE_HDU, read the corresponding image.  Compression
         and scaling are dealt with properly.
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being "
-                    "ignored! This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "The keyword arguments '%s' are being "
+                "ignored! This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
-            if not self.has_data():
-                return None
+        if not self.has_data():
+            return None
 
-            dtype, shape = self._get_dtype_and_shape()
-            array = numpy.zeros(shape, dtype=dtype)
-            self._FITS.read_image(self._ext + 1, array)
-            return array
+        dtype, shape = self._get_dtype_and_shape()
+        array = numpy.zeros(shape, dtype=dtype)
+        self._FITS.read_image(self._ext + 1, array)
+        return array
 
     def _get_dtype_and_shape(self):
         """

--- a/fitsio/hdu/image.py
+++ b/fitsio/hdu/image.py
@@ -250,6 +250,7 @@ class ImageHDU(HDUBase):
         If the HDU is an IMAGE_HDU, read the corresponding image.  Compression
         and scaling are dealt with properly.
         """
+
         if keys:
             import warnings
 

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -1000,7 +1000,6 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-
         if keys:
             import warnings
 

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -207,9 +207,7 @@ class TableHDU(HDUBase):
         elif lastrow > self._info['nrows']:
             raise ValueError('lastrow cannot be greater than nrows')
         nrows = lastrow - firstrow
-        return self._FITS.where(
-            self._ext + 1, expression, firstrow + 1, nrows
-        )
+        return self._FITS.where(self._ext + 1, expression, firstrow + 1, nrows)
 
     def write(
         self, data, firstrow=0, columns=None, names=None, slow=False, **keys

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -831,6 +831,7 @@ class TableHDU(HDUBase):
         colnums: integer array, optional
             The column numbers, 0 offset
         """
+
         if keys:
             import warnings
 
@@ -999,6 +1000,7 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
+
         if keys:
             import warnings
 
@@ -1117,6 +1119,7 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
+
         if keys:
             import warnings
 
@@ -1253,6 +1256,7 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
+
         if keys:
             import warnings
 

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -81,6 +81,7 @@ class TableHDU(HDUBase):
         self,
         fits,
         ext,
+        lock=None,
         lower=False,
         upper=False,
         trim_strings=False,
@@ -102,7 +103,7 @@ class TableHDU(HDUBase):
 
         # NOTE: The defaults of False above cannot be changed since they
         # are or'ed with the method defaults below.
-        super(TableHDU, self).__init__(fits, ext)
+        super(TableHDU, self).__init__(fits, ext, lock=lock)
 
         self.lower = lower
         self.upper = upper
@@ -113,10 +114,29 @@ class TableHDU(HDUBase):
         self._iter_row_buffer = iter_row_buffer
         self.write_bitcols = write_bitcols
 
-        if self._info['hdutype'] == ASCII_TBL:
-            self._table_type_str = 'ascii'
-        else:
-            self._table_type_str = 'binary'
+    def _update_info(self):
+        """
+        Call parent method and make sure this is in fact a
+        table HDU.  Set some convenience data.
+        """
+        with self._lock:
+            super(TableHDU, self)._update_info()
+            if self._info['hdutype'] == IMAGE_HDU:
+                mess = "Extension %s is not a Table HDU" % self.ext
+                raise ValueError(mess)
+            if 'colinfo' in self._info:
+                self._info["colnames"] = [
+                    i['name'] for i in self._info['colinfo']
+                ]
+                self._info["colnames_lower"] = [
+                    i['name'].lower() for i in self._info['colinfo']
+                ]
+                self._info["ncol"] = len(self._info["colnames"])
+
+            if self._info['hdutype'] == ASCII_TBL:
+                self._table_type_str = 'ascii'
+            else:
+                self._table_type_str = 'binary'
 
     def get_nrows(self):
         """
@@ -190,7 +210,10 @@ class TableHDU(HDUBase):
         elif lastrow > self._info['nrows']:
             raise ValueError('lastrow cannot be greater than nrows')
         nrows = lastrow - firstrow
-        return self._FITS.where(self._ext + 1, expression, firstrow + 1, nrows)
+        with self._lock:
+            return self._FITS.where(
+                self._ext + 1, expression, firstrow + 1, nrows
+            )
 
     def write(
         self, data, firstrow=0, columns=None, names=None, slow=False, **keys
@@ -223,108 +246,119 @@ class TableHDU(HDUBase):
             for debugging.
         """
 
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        isrec = False
-        if isinstance(data, (list, dict)):
-            if isinstance(data, list):
-                data_list = data
-                if columns is not None:
-                    columns_all = columns
-                elif names is not None:
-                    columns_all = names
-                else:
-                    raise ValueError(
-                        "you must send `columns` or `names` "
-                        "with a list of arrays"
-                    )
-            else:
-                columns_all = list(data.keys())
-                data_list = [data[n] for n in columns_all]
-
-            colnums_all = [self._extract_colnum(c) for c in columns_all]
-            names = [self.get_colname(c) for c in colnums_all]
-
-            isobj = np.zeros(len(data_list), dtype=bool)
-            for i in xrange(len(data_list)):
-                isobj[i] = is_object(data_list[i])
-
-        else:
-            if data.dtype.fields is None:
-                raise ValueError(
-                    "You are writing to a table, so I expected "
-                    "an array with fields as input. If you want "
-                    "to write a simple array, you should use "
-                    "write_column to write to a single column, "
-                    "or instead write to an image hdu"
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
 
-            if data.shape == ():
-                raise ValueError("cannot write data with shape ()")
-
-            isrec = True
-            names = data.dtype.names
-            # only write object types (variable-length columns) after
-            # writing the main table
-            isobj = fields_are_object(data)
-
-            data_list = []
-            colnums_all = []
-            for i, name in enumerate(names):
-                colnum = self._extract_colnum(name)
-                data_list.append(data[name])
-                colnums_all.append(colnum)
-
-        if slow:
-            for i, name in enumerate(names):
-                if not isobj[i]:
-                    self.write_column(name, data_list[i], firstrow=firstrow)
-        else:
-            nonobj_colnums = []
-            nonobj_arrays = []
-            for i in xrange(len(data_list)):
-                if not isobj[i]:
-                    nonobj_colnums.append(colnums_all[i])
-                    if isrec:
-                        # this still leaves possibility of f-order sub-arrays..
-                        colref = array_to_native(data_list[i], inplace=False)
+            isrec = False
+            if isinstance(data, (list, dict)):
+                if isinstance(data, list):
+                    data_list = data
+                    if columns is not None:
+                        columns_all = columns
+                    elif names is not None:
+                        columns_all = names
                     else:
-                        colref = array_to_native_c(data_list[i], inplace=False)
+                        raise ValueError(
+                            "you must send `columns` or `names` "
+                            "with a list of arrays"
+                        )
+                else:
+                    columns_all = list(data.keys())
+                    data_list = [data[n] for n in columns_all]
 
-                    if IS_PY3 and colref.dtype.char == 'U':
-                        # for python3, we convert unicode to ascii
-                        # this will error if the character is not in ascii
-                        colref = colref.astype('S', copy=copy_if_needed)
+                colnums_all = [self._extract_colnum(c) for c in columns_all]
+                names = [self.get_colname(c) for c in colnums_all]
 
-                    nonobj_arrays.append(colref)
+                isobj = np.zeros(len(data_list), dtype=bool)
+                for i in xrange(len(data_list)):
+                    isobj[i] = is_object(data_list[i])
 
-            for tcolnum, tdata in zip(nonobj_colnums, nonobj_arrays):
-                self._verify_column_data(tcolnum, tdata)
+            else:
+                if data.dtype.fields is None:
+                    raise ValueError(
+                        "You are writing to a table, so I expected "
+                        "an array with fields as input. If you want "
+                        "to write a simple array, you should use "
+                        "write_column to write to a single column, "
+                        "or instead write to an image hdu"
+                    )
 
-            if len(nonobj_arrays) > 0:
-                self._FITS.write_columns(
-                    self._ext + 1,
-                    nonobj_colnums,
-                    nonobj_arrays,
-                    firstrow=firstrow + 1,
-                    write_bitcols=self.write_bitcols,
-                )
+                if data.shape == ():
+                    raise ValueError("cannot write data with shape ()")
 
-        # writing the object arrays always occurs the same way
-        # need to make sure this works for array fields
-        for i, name in enumerate(names):
-            if isobj[i]:
-                self.write_var_column(name, data_list[i], firstrow=firstrow)
+                isrec = True
+                names = data.dtype.names
+                # only write object types (variable-length columns) after
+                # writing the main table
+                isobj = fields_are_object(data)
 
-        self._cached_info = None  # invalidate info cache
+                data_list = []
+                colnums_all = []
+                for i, name in enumerate(names):
+                    colnum = self._extract_colnum(name)
+                    data_list.append(data[name])
+                    colnums_all.append(colnum)
+
+            if slow:
+                for i, name in enumerate(names):
+                    if not isobj[i]:
+                        self.write_column(
+                            name, data_list[i], firstrow=firstrow
+                        )
+            else:
+                nonobj_colnums = []
+                nonobj_arrays = []
+                for i in xrange(len(data_list)):
+                    if not isobj[i]:
+                        nonobj_colnums.append(colnums_all[i])
+                        if isrec:
+                            # this still leaves possibility of
+                            # f-order sub-arrays..
+                            colref = array_to_native(
+                                data_list[i], inplace=False
+                            )
+                        else:
+                            colref = array_to_native_c(
+                                data_list[i], inplace=False
+                            )
+
+                        if IS_PY3 and colref.dtype.char == 'U':
+                            # for python3, we convert unicode to ascii
+                            # this will error if the character is not in ascii
+                            colref = colref.astype('S', copy=copy_if_needed)
+
+                        nonobj_arrays.append(colref)
+
+                for tcolnum, tdata in zip(nonobj_colnums, nonobj_arrays):
+                    self._verify_column_data(tcolnum, tdata)
+
+                if len(nonobj_arrays) > 0:
+                    self._FITS.write_columns(
+                        self._ext + 1,
+                        nonobj_colnums,
+                        nonobj_arrays,
+                        firstrow=firstrow + 1,
+                        write_bitcols=self.write_bitcols,
+                    )
+
+            # writing the object arrays always occurs the same way
+            # need to make sure this works for array fields
+            for i, name in enumerate(names):
+                if isobj[i]:
+                    self.write_var_column(
+                        name, data_list[i], firstrow=firstrow
+                    )
+
+            self._cached_info = None  # invalidate info cache
 
     def write_column(self, column, data, firstrow=0, **keys):
         """
@@ -345,49 +379,51 @@ class TableHDU(HDUBase):
             are doing!  For appending see the append() method.  Default 0.
         """
 
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            colnum = self._extract_colnum(column)
+
+            # need it to be contiguous and native byte order.  For now, make a
+            # copy.  but we may be able to avoid this with some care.
+
+            if not data.flags['C_CONTIGUOUS']:
+                # this always makes a copy
+                data_send = np.ascontiguousarray(data)
+                # this is a copy, we can make sure it is native
+                # and modify in place if needed
+                data_send = array_to_native(data_send, inplace=True)
+            else:
+                # we can avoid the copy with a try-finally block and
+                # some logic
+                data_send = array_to_native(data, inplace=False)
+
+            if IS_PY3 and data_send.dtype.char == 'U':
+                # for python3, we convert unicode to ascii
+                # this will error if the character is not in ascii
+                data_send = data_send.astype('S', copy=copy_if_needed)
+
+            self._verify_column_data(colnum, data_send)
+
+            self._FITS.write_columns(
+                self._ext + 1,
+                [colnum],
+                [data_send],
+                firstrow=firstrow + 1,
+                write_bitcols=self.write_bitcols,
             )
 
-        colnum = self._extract_colnum(column)
-
-        # need it to be contiguous and native byte order.  For now, make a
-        # copy.  but we may be able to avoid this with some care.
-
-        if not data.flags['C_CONTIGUOUS']:
-            # this always makes a copy
-            data_send = np.ascontiguousarray(data)
-            # this is a copy, we can make sure it is native
-            # and modify in place if needed
-            data_send = array_to_native(data_send, inplace=True)
-        else:
-            # we can avoid the copy with a try-finally block and
-            # some logic
-            data_send = array_to_native(data, inplace=False)
-
-        if IS_PY3 and data_send.dtype.char == 'U':
-            # for python3, we convert unicode to ascii
-            # this will error if the character is not in ascii
-            data_send = data_send.astype('S', copy=copy_if_needed)
-
-        self._verify_column_data(colnum, data_send)
-
-        self._FITS.write_columns(
-            self._ext + 1,
-            [colnum],
-            [data_send],
-            firstrow=firstrow + 1,
-            write_bitcols=self.write_bitcols,
-        )
-
-        del data_send
-        self._cached_info = None  # invalidate info cache
+            del data_send
+            self._cached_info = None  # invalidate info cache
 
     def _verify_column_data(self, colnum, data):
         """
@@ -463,26 +499,29 @@ class TableHDU(HDUBase):
             are doing!  For appending see the append() method.  Default 0.
         """
 
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! This "
+                    "warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            if not is_object(data):
+                raise ValueError(
+                    "Only object fields can be written to variable-length "
+                    "arrays"
+                )
+            colnum = self._extract_colnum(column)
+
+            self._FITS.write_var_column(
+                self._ext + 1, colnum + 1, data, firstrow=firstrow + 1
             )
-
-        if not is_object(data):
-            raise ValueError(
-                "Only object fields can be written to variable-length arrays"
-            )
-        colnum = self._extract_colnum(column)
-
-        self._FITS.write_var_column(
-            self._ext + 1, colnum + 1, data, firstrow=firstrow + 1
-        )
-        self._cached_info = None  # invalidate info cache
+            self._cached_info = None  # invalidate info cache
 
     def insert_column(
         self, name, data, colnum=None, write_bitcols=None, **keys
@@ -509,61 +548,66 @@ class TableHDU(HDUBase):
         This method is used un-modified by ascii tables as well.
         """
 
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            if write_bitcols is None:
+                write_bitcols = self.write_bitcols
+
+            if name in self._info["colnames"]:
+                raise ValueError("column '%s' already exists" % name)
+
+            if IS_PY3 and data.dtype.char == 'U':
+                # fast dtype conversion using an empty array
+                # we could hack at the actual text description, but using
+                # the numpy API is probably safer
+                # this also avoids doing a dtype conversion on every array
+                # element which could b expensive
+                descr = np.empty(1).astype(data.dtype).astype('S').dtype.descr
+            else:
+                descr = data.dtype.descr
+
+            if len(descr) > 1:
+                raise ValueError(
+                    "you can only insert a single column, requested: %s"
+                    % descr
+                )
+
+            this_descr = descr[0]
+            this_descr = [name, this_descr[1]]
+            if len(data.shape) > 1:
+                this_descr += [data.shape[1:]]
+            this_descr = tuple(this_descr)
+
+            name, fmt, dims = _npy2fits(
+                this_descr,
+                table_type=self._table_type_str,
+                write_bitcols=write_bitcols,
+            )
+            if dims is not None:
+                dims = [dims]
+
+            if colnum is None:
+                new_colnum = len(self._info['colinfo']) + 1
+            else:
+                new_colnum = colnum + 1
+
+            self._FITS.insert_col(
+                self._ext + 1, new_colnum, name, fmt, tdim=dims
             )
 
-        if write_bitcols is None:
-            write_bitcols = self.write_bitcols
+            self._cached_info = None  # invalidate info cache
 
-        if name in self._info["colnames"]:
-            raise ValueError("column '%s' already exists" % name)
-
-        if IS_PY3 and data.dtype.char == 'U':
-            # fast dtype conversion using an empty array
-            # we could hack at the actual text description, but using
-            # the numpy API is probably safer
-            # this also avoids doing a dtype conversion on every array
-            # element which could b expensive
-            descr = np.empty(1).astype(data.dtype).astype('S').dtype.descr
-        else:
-            descr = data.dtype.descr
-
-        if len(descr) > 1:
-            raise ValueError(
-                "you can only insert a single column, requested: %s" % descr
-            )
-
-        this_descr = descr[0]
-        this_descr = [name, this_descr[1]]
-        if len(data.shape) > 1:
-            this_descr += [data.shape[1:]]
-        this_descr = tuple(this_descr)
-
-        name, fmt, dims = _npy2fits(
-            this_descr,
-            table_type=self._table_type_str,
-            write_bitcols=write_bitcols,
-        )
-        if dims is not None:
-            dims = [dims]
-
-        if colnum is None:
-            new_colnum = len(self._info['colinfo']) + 1
-        else:
-            new_colnum = colnum + 1
-
-        self._FITS.insert_col(self._ext + 1, new_colnum, name, fmt, tdim=dims)
-
-        self._cached_info = None  # invalidate info cache
-
-        self.write_column(name, data)
+            self.write_column(name, data)
 
     def append(self, data, columns=None, names=None, **keys):
         """
@@ -585,18 +629,20 @@ class TableHDU(HDUBase):
             of names or column numbers. You can also use the `columns` keyword
             argument.
         """
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
-        firstrow = self._info['nrows']
-        self.write(data, firstrow=firstrow, columns=columns, names=names)
+            firstrow = self._info['nrows']
+            self.write(data, firstrow=firstrow, columns=columns, names=names)
 
     def delete_rows(self, rows):
         """
@@ -618,36 +664,38 @@ class TableHDU(HDUBase):
                 rows2delete = [3,88,76]
                 fits['mytable'].delete_rows(rows2delete)
         """
-
-        if rows is None:
-            return
-
-        # extract and convert to 1-offset for C routine
-        if isinstance(rows, slice):
-            rows = self._process_slice(rows)
-            if rows.step is not None and rows.step != 1:
-                rows = np.arange(
-                    rows.start + 1,
-                    rows.stop + 1,
-                    rows.step,
-                )
-            else:
-                # rows must be 1-offset
-                rows = slice(rows.start + 1, rows.stop + 1)
-        else:
-            rows, sortind = self._extract_rows(rows, sort=True)
-            # rows must be 1-offset
-            rows += 1
-
-        if isinstance(rows, slice):
-            self._FITS.delete_row_range(self._ext + 1, rows.start, rows.stop)
-        else:
-            if rows.size == 0:
+        with self._lock:
+            if rows is None:
                 return
 
-            self._FITS.delete_rows(self._ext + 1, rows)
+            # extract and convert to 1-offset for C routine
+            if isinstance(rows, slice):
+                rows = self._process_slice(rows)
+                if rows.step is not None and rows.step != 1:
+                    rows = np.arange(
+                        rows.start + 1,
+                        rows.stop + 1,
+                        rows.step,
+                    )
+                else:
+                    # rows must be 1-offset
+                    rows = slice(rows.start + 1, rows.stop + 1)
+            else:
+                rows, sortind = self._extract_rows(rows, sort=True)
+                # rows must be 1-offset
+                rows += 1
 
-        self._cached_info = None  # invalidate info cache
+            if isinstance(rows, slice):
+                self._FITS.delete_row_range(
+                    self._ext + 1, rows.start, rows.stop
+                )
+            else:
+                if rows.size == 0:
+                    return
+
+                self._FITS.delete_rows(self._ext + 1, rows)
+
+            self._cached_info = None  # invalidate info cache
 
     def resize(self, nrows, front=False):
         """
@@ -667,33 +715,33 @@ class TableHDU(HDUBase):
             If True, add or remove rows from the front.  Default
             is False
         """
+        with self._lock:
+            nrows_current = self.get_nrows()
+            if nrows == nrows_current:
+                return
 
-        nrows_current = self.get_nrows()
-        if nrows == nrows_current:
-            return
+            if nrows < nrows_current:
+                rowdiff = nrows_current - nrows
+                if front:
+                    # delete from the front
+                    start = 0
+                    stop = rowdiff
+                else:
+                    # delete from the back
+                    start = nrows
+                    stop = nrows_current
 
-        if nrows < nrows_current:
-            rowdiff = nrows_current - nrows
-            if front:
-                # delete from the front
-                start = 0
-                stop = rowdiff
+                self.delete_rows(slice(start, stop))
             else:
-                # delete from the back
-                start = nrows
-                stop = nrows_current
+                rowdiff = nrows - nrows_current
+                if front:
+                    # in this case zero is what we want, since the code inserts
+                    firstrow = 0
+                else:
+                    firstrow = nrows_current
+                self._FITS.insert_rows(self._ext + 1, firstrow, rowdiff)
 
-            self.delete_rows(slice(start, stop))
-        else:
-            rowdiff = nrows - nrows_current
-            if front:
-                # in this case zero is what we want, since the code inserts
-                firstrow = 0
-            else:
-                firstrow = nrows_current
-            self._FITS.insert_rows(self._ext + 1, firstrow, rowdiff)
-
-        self._cached_info = None  # invalidate info cache
+            self._cached_info = None  # invalidate info cache
 
     def read(
         self,
@@ -746,44 +794,46 @@ class TableHDU(HDUBase):
             trim_strings= keyword from constructor.
         """
 
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
-        if columns is not None:
-            data = self.read_columns(
-                columns,
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-        elif rows is not None:
-            # combinations of row and column subsets are covered by
-            # read_columns so we pass colnums=None here to get all columns
-            data = self.read_rows(
-                rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-        else:
-            data = self._read_all(
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
+            if columns is not None:
+                data = self.read_columns(
+                    columns,
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
+            elif rows is not None:
+                # combinations of row and column subsets are covered by
+                # read_columns so we pass colnums=None here to get all columns
+                data = self.read_rows(
+                    rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
+            else:
+                data = self._read_all(
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
 
-        return data
+            return data
 
     def _read_all(
         self,
@@ -814,77 +864,80 @@ class TableHDU(HDUBase):
         colnums: integer array, optional
             The column numbers, 0 offset
         """
+        with self._lock:
+            if keys:
+                import warnings
 
-        if keys:
-            import warnings
-
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        dtype, offsets, isvar = self.get_rec_dtype(
-            colnums=colnums, vstorage=vstorage
-        )
-
-        (w,) = np.where(isvar == True)  # noqa
-        has_tbit = self._check_tbit()
-
-        if w.size > 0:
-            if vstorage is None:
-                _vstorage = self._vstorage
-            else:
-                _vstorage = vstorage
-            colnums = self._extract_colnums()
-            rows = None
-            sortind = None
-            array = self._read_rec_with_var(
-                colnums,
-                rows,
-                sortind,
-                dtype,
-                offsets,
-                isvar,
-                _vstorage,
-            )
-        elif has_tbit:
-            # drop down to read_columns since we can't stuff into a
-            # contiguous array
-            colnums = self._extract_colnums()
-            array = self.read_columns(
-                colnums,
-                rows=None,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-        else:
-            firstrow = 1  # noqa - not used?
-            nrows = self._info['nrows']
-            array = np.zeros(nrows, dtype=dtype)
-
-            self._FITS.read_as_rec(self._ext + 1, 1, nrows, array)
-
-            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
-
-            for colnum, name in enumerate(array.dtype.names):
-                self._rescale_and_convert_field_inplace(
-                    array,
-                    name,
-                    self._info['colinfo'][colnum]['tscale'],
-                    self._info['colinfo'][colnum]['tzero'],
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
 
-        if self.lower or lower:
-            _names_to_lower_if_recarray(array)
-        elif self.upper or upper:
-            _names_to_upper_if_recarray(array)
+            dtype, offsets, isvar = self.get_rec_dtype(
+                colnums=colnums, vstorage=vstorage
+            )
 
-        self._maybe_trim_strings(array, trim_strings=trim_strings)
-        return array
+            (w,) = np.where(isvar == True)  # noqa
+            has_tbit = self._check_tbit()
+
+            if w.size > 0:
+                if vstorage is None:
+                    _vstorage = self._vstorage
+                else:
+                    _vstorage = vstorage
+                colnums = self._extract_colnums()
+                rows = None
+                sortind = None
+                array = self._read_rec_with_var(
+                    colnums,
+                    rows,
+                    sortind,
+                    dtype,
+                    offsets,
+                    isvar,
+                    _vstorage,
+                )
+            elif has_tbit:
+                # drop down to read_columns since we can't stuff into a
+                # contiguous array
+                colnums = self._extract_colnums()
+                array = self.read_columns(
+                    colnums,
+                    rows=None,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
+            else:
+                firstrow = 1  # noqa - not used?
+                nrows = self._info['nrows']
+                array = np.zeros(nrows, dtype=dtype)
+
+                self._FITS.read_as_rec(self._ext + 1, 1, nrows, array)
+
+                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
+                    array
+                )
+
+                for colnum, name in enumerate(array.dtype.names):
+                    self._rescale_and_convert_field_inplace(
+                        array,
+                        name,
+                        self._info['colinfo'][colnum]['tscale'],
+                        self._info['colinfo'][colnum]['tzero'],
+                    )
+
+            if self.lower or lower:
+                _names_to_lower_if_recarray(array)
+            elif self.upper or upper:
+                _names_to_upper_if_recarray(array)
+
+            self._maybe_trim_strings(array, trim_strings=trim_strings)
+            return array
 
     def read_column(
         self,
@@ -930,29 +983,31 @@ class TableHDU(HDUBase):
             trim_strings= keyword from constructor.
         """
 
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            res = self.read_columns(
+                [col],
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
             )
+            colname = res.dtype.names[0]
+            data = res[colname]
 
-        res = self.read_columns(
-            [col],
-            rows=rows,
-            vstorage=vstorage,
-            upper=upper,
-            lower=lower,
-            trim_strings=trim_strings,
-        )
-        colname = res.dtype.names[0]
-        data = res[colname]
-
-        self._maybe_trim_strings(data, trim_strings=trim_strings)
-        return data
+            self._maybe_trim_strings(data, trim_strings=trim_strings)
+            return data
 
     def read_rows(
         self,
@@ -983,84 +1038,90 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        if rows is None:
-            # we actually want all rows!
-            return self._read_all()
-
-        if self._info['hdutype'] == ASCII_TBL:
-            return self.read(
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-
-        rows, sortind = self._extract_rows(rows)
-        dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
-
-        (w,) = np.where(isvar == True)  # noqa
-        has_tbit = self._check_tbit()
-
-        if w.size > 0:
-            if vstorage is None:
-                _vstorage = self._vstorage
-            else:
-                _vstorage = vstorage
-            colnums = self._extract_colnums()
-            return self._read_rec_with_var(
-                colnums,
-                rows,
-                sortind,
-                dtype,
-                offsets,
-                isvar,
-                _vstorage,
-            )
-        elif has_tbit:
-            # drop down to read_columns since we can't stuff into a
-            # contiguous array
-            colnums = self._extract_colnums()
-            array = self.read_columns(
-                colnums,
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-        else:
-            array = np.zeros(rows.size, dtype=dtype)
-            self._FITS.read_rows_as_rec(self._ext + 1, array, rows, sortind)
-
-            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
-
-            for colnum, name in enumerate(array.dtype.names):
-                self._rescale_and_convert_field_inplace(
-                    array,
-                    name,
-                    self._info['colinfo'][colnum]['tscale'],
-                    self._info['colinfo'][colnum]['tzero'],
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
 
-        if self.lower or lower:
-            _names_to_lower_if_recarray(array)
-        elif self.upper or upper:
-            _names_to_upper_if_recarray(array)
+            if rows is None:
+                # we actually want all rows!
+                return self._read_all()
 
-        self._maybe_trim_strings(array, trim_strings=trim_strings)
+            if self._info['hdutype'] == ASCII_TBL:
+                return self.read(
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
 
-        return array
+            rows, sortind = self._extract_rows(rows)
+            dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
+
+            (w,) = np.where(isvar == True)  # noqa
+            has_tbit = self._check_tbit()
+
+            if w.size > 0:
+                if vstorage is None:
+                    _vstorage = self._vstorage
+                else:
+                    _vstorage = vstorage
+                colnums = self._extract_colnums()
+                return self._read_rec_with_var(
+                    colnums,
+                    rows,
+                    sortind,
+                    dtype,
+                    offsets,
+                    isvar,
+                    _vstorage,
+                )
+            elif has_tbit:
+                # drop down to read_columns since we can't stuff into a
+                # contiguous array
+                colnums = self._extract_colnums()
+                array = self.read_columns(
+                    colnums,
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
+            else:
+                array = np.zeros(rows.size, dtype=dtype)
+                self._FITS.read_rows_as_rec(
+                    self._ext + 1, array, rows, sortind
+                )
+
+                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
+                    array
+                )
+
+                for colnum, name in enumerate(array.dtype.names):
+                    self._rescale_and_convert_field_inplace(
+                        array,
+                        name,
+                        self._info['colinfo'][colnum]['tscale'],
+                        self._info['colinfo'][colnum]['tzero'],
+                    )
+
+            if self.lower or lower:
+                _names_to_lower_if_recarray(array)
+            elif self.upper or upper:
+                _names_to_upper_if_recarray(array)
+
+            self._maybe_trim_strings(array, trim_strings=trim_strings)
+
+            return array
 
     def read_columns(
         self,
@@ -1101,101 +1162,105 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
+        with self._lock:
+            if keys:
+                import warnings
 
-        if keys:
-            import warnings
-
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        if self._info['hdutype'] == ASCII_TBL:
-            return self.read(
-                columns=columns,
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-
-        # if columns is None, returns all.  Guaranteed to be unique and sorted
-        colnums = self._extract_colnums(columns)
-        if isinstance(colnums, int):
-            # scalar sent, don't read as a recarray
-            return self.read_column(
-                columns,
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-
-        # if rows is None still returns None, and is correctly interpreted
-        # by the reader to mean all
-        rows, sortind = self._extract_rows(rows)
-
-        # this is the full dtype for all columns
-        dtype, offsets, isvar = self.get_rec_dtype(
-            colnums=colnums, vstorage=vstorage
-        )
-
-        (w,) = np.where(isvar == True)  # noqa
-        if w.size > 0:
-            if vstorage is None:
-                _vstorage = self._vstorage
-            else:
-                _vstorage = vstorage
-            array = self._read_rec_with_var(
-                colnums,
-                rows,
-                sortind,
-                dtype,
-                offsets,
-                isvar,
-                _vstorage,
-            )
-        else:
-            if rows is None:
-                nrows = self._info['nrows']
-            else:
-                nrows = rows.size
-
-            array = np.zeros(nrows, dtype=dtype)
-
-            colnumsp = colnums[:].copy()
-            colnumsp[:] += 1
-            self._FITS.read_columns_as_rec(
-                self._ext + 1, colnumsp, array, rows, sortind
-            )
-
-            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
-
-            for i in xrange(colnums.size):
-                colnum = int(colnums[i])
-                name = array.dtype.names[i]
-                self._rescale_and_convert_field_inplace(
-                    array,
-                    name,
-                    self._info['colinfo'][colnum]['tscale'],
-                    self._info['colinfo'][colnum]['tzero'],
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
 
-        if self._check_tbit(colnums=colnums):
-            array = self._fix_tbit_dtype(array, colnums)
+            if self._info['hdutype'] == ASCII_TBL:
+                return self.read(
+                    columns=columns,
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
 
-        if self.lower or lower:
-            _names_to_lower_if_recarray(array)
-        elif self.upper or upper:
-            _names_to_upper_if_recarray(array)
+            # if columns is None, returns all.  Guaranteed to be unique and
+            # sorted
+            colnums = self._extract_colnums(columns)
+            if isinstance(colnums, int):
+                # scalar sent, don't read as a recarray
+                return self.read_column(
+                    columns,
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
 
-        self._maybe_trim_strings(array, trim_strings=trim_strings)
+            # if rows is None still returns None, and is correctly interpreted
+            # by the reader to mean all
+            rows, sortind = self._extract_rows(rows)
 
-        return array
+            # this is the full dtype for all columns
+            dtype, offsets, isvar = self.get_rec_dtype(
+                colnums=colnums, vstorage=vstorage
+            )
+
+            (w,) = np.where(isvar == True)  # noqa
+            if w.size > 0:
+                if vstorage is None:
+                    _vstorage = self._vstorage
+                else:
+                    _vstorage = vstorage
+                array = self._read_rec_with_var(
+                    colnums,
+                    rows,
+                    sortind,
+                    dtype,
+                    offsets,
+                    isvar,
+                    _vstorage,
+                )
+            else:
+                if rows is None:
+                    nrows = self._info['nrows']
+                else:
+                    nrows = rows.size
+
+                array = np.zeros(nrows, dtype=dtype)
+
+                colnumsp = colnums[:].copy()
+                colnumsp[:] += 1
+                self._FITS.read_columns_as_rec(
+                    self._ext + 1, colnumsp, array, rows, sortind
+                )
+
+                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
+                    array
+                )
+
+                for i in xrange(colnums.size):
+                    colnum = int(colnums[i])
+                    name = array.dtype.names[i]
+                    self._rescale_and_convert_field_inplace(
+                        array,
+                        name,
+                        self._info['colinfo'][colnum]['tscale'],
+                        self._info['colinfo'][colnum]['tzero'],
+                    )
+
+            if self._check_tbit(colnums=colnums):
+                array = self._fix_tbit_dtype(array, colnums)
+
+            if self.lower or lower:
+                _names_to_lower_if_recarray(array)
+            elif self.upper or upper:
+                _names_to_upper_if_recarray(array)
+
+            self._maybe_trim_strings(array, trim_strings=trim_strings)
+
+            return array
 
     def read_slice(
         self,
@@ -1238,100 +1303,103 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
+        with self._lock:
+            if keys:
+                import warnings
 
-        if keys:
-            import warnings
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        if self._info['hdutype'] == ASCII_TBL:
-            rows = np.arange(firstrow, lastrow, step, dtype='i8')
-            return self.read_ascii(
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-
-        if self._info['hdutype'] == IMAGE_HDU:
-            raise ValueError("slices currently only supported for tables")
-
-        maxrow = self._info['nrows']
-        if firstrow < 0 or lastrow > maxrow:
-            raise ValueError(
-                "slice must specify a sub-range of [%d,%d]" % (0, maxrow)
-            )
-
-        dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
-
-        (w,) = np.where(isvar == True)  # noqa
-        has_tbit = self._check_tbit()
-
-        if w.size > 0:
-            if vstorage is None:
-                _vstorage = self._vstorage
-            else:
-                _vstorage = vstorage
-            rows = np.arange(firstrow, lastrow, step, dtype='i8')
-            sortind = np.arange(rows.size, dtype='i8')
-            colnums = self._extract_colnums()
-            array = self._read_rec_with_var(
-                colnums, rows, sortind, dtype, offsets, isvar, _vstorage
-            )
-        elif has_tbit:
-            # drop down to read_columns since we can't stuff into a
-            # contiguous array
-            colnums = self._extract_colnums()
-            rows = np.arange(firstrow, lastrow, step, dtype='i8')
-            array = self.read_columns(
-                colnums,
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-        else:
-            if step != 1:
+            if self._info['hdutype'] == ASCII_TBL:
                 rows = np.arange(firstrow, lastrow, step, dtype='i8')
-                array = self.read(rows=rows)
+                return self.read_ascii(
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
+
+            if self._info['hdutype'] == IMAGE_HDU:
+                raise ValueError("slices currently only supported for tables")
+
+            maxrow = self._info['nrows']
+            if firstrow < 0 or lastrow > maxrow:
+                raise ValueError(
+                    "slice must specify a sub-range of [%d,%d]" % (0, maxrow)
+                )
+
+            dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
+
+            (w,) = np.where(isvar == True)  # noqa
+            has_tbit = self._check_tbit()
+
+            if w.size > 0:
+                if vstorage is None:
+                    _vstorage = self._vstorage
+                else:
+                    _vstorage = vstorage
+                rows = np.arange(firstrow, lastrow, step, dtype='i8')
+                sortind = np.arange(rows.size, dtype='i8')
+                colnums = self._extract_colnums()
+                array = self._read_rec_with_var(
+                    colnums, rows, sortind, dtype, offsets, isvar, _vstorage
+                )
+            elif has_tbit:
+                # drop down to read_columns since we can't stuff into a
+                # contiguous array
+                colnums = self._extract_colnums()
+                rows = np.arange(firstrow, lastrow, step, dtype='i8')
+                array = self.read_columns(
+                    colnums,
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
+                )
             else:
-                # no +1 because lastrow is non-inclusive
-                nrows = lastrow - firstrow
-                array = np.zeros(nrows, dtype=dtype)
+                if step != 1:
+                    rows = np.arange(firstrow, lastrow, step, dtype='i8')
+                    array = self.read(rows=rows)
+                else:
+                    # no +1 because lastrow is non-inclusive
+                    nrows = lastrow - firstrow
+                    array = np.zeros(nrows, dtype=dtype)
 
-                # only first needs to be +1.  This is becuase the c code is
-                # inclusive
-                self._FITS.read_as_rec(
-                    self._ext + 1, firstrow + 1, lastrow, array
-                )
-
-                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
-                    array
-                )
-
-                for colnum, name in enumerate(array.dtype.names):
-                    self._rescale_and_convert_field_inplace(
-                        array,
-                        name,
-                        self._info['colinfo'][colnum]['tscale'],
-                        self._info['colinfo'][colnum]['tzero'],
+                    # only first needs to be +1.  This is becuase the c code is
+                    # inclusive
+                    self._FITS.read_as_rec(
+                        self._ext + 1, firstrow + 1, lastrow, array
                     )
 
-        if self.lower or lower:
-            _names_to_lower_if_recarray(array)
-        elif self.upper or upper:
-            _names_to_upper_if_recarray(array)
+                    array = (
+                        self._maybe_decode_fits_ascii_strings_to_unicode_py3(
+                            array
+                        )
+                    )
 
-        self._maybe_trim_strings(array, trim_strings=trim_strings)
+                    for colnum, name in enumerate(array.dtype.names):
+                        self._rescale_and_convert_field_inplace(
+                            array,
+                            name,
+                            self._info['colinfo'][colnum]['tscale'],
+                            self._info['colinfo'][colnum]['tzero'],
+                        )
 
-        return array
+            if self.lower or lower:
+                _names_to_lower_if_recarray(array)
+            elif self.upper or upper:
+                _names_to_upper_if_recarray(array)
+
+            self._maybe_trim_strings(array, trim_strings=trim_strings)
+
+            return array
 
     def get_rec_dtype(self, colnums=None, vstorage=None, **keys):
         """
@@ -2010,22 +2078,6 @@ class TableHDU(HDUBase):
                 raise ValueError(mess)
         return int(colnum)
 
-    def _update_info(self):
-        """
-        Call parent method and make sure this is in fact a
-        table HDU.  Set some convenience data.
-        """
-        super(TableHDU, self)._update_info()
-        if self._info['hdutype'] == IMAGE_HDU:
-            mess = "Extension %s is not a Table HDU" % self.ext
-            raise ValueError(mess)
-        if 'colinfo' in self._info:
-            self._info["colnames"] = [i['name'] for i in self._info['colinfo']]
-            self._info["colnames_lower"] = [
-                i['name'].lower() for i in self._info['colinfo']
-            ]
-            self._info["ncol"] = len(self._info["colnames"])
-
     def __getitem__(self, arg):
         """
         Get data from a table using python [] notation.
@@ -2230,107 +2282,110 @@ class AsciiTableHDU(TableHDU):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-        if keys:
-            import warnings
+        with self._lock:
+            if keys:
+                import warnings
 
-            warnings.warn(
-                "The keyword arguments '%s' are being ignored! This warning "
-                "will be an error in a future version of `fitsio`!" % keys,
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        # if columns is None, returns all.  Guaranteed to be unique and sorted
-        colnums = self._extract_colnums(columns)
-        if isinstance(colnums, int):
-            # scalar sent, don't read as a recarray
-            return self.read_column(
-                columns,
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
-            )
-
-        rows, sortind = self._extract_rows(rows)
-        if rows is None:
-            nrows = self._info['nrows']
-        else:
-            nrows = rows.size
-
-        # if rows is None still returns None, and is correctly interpreted
-        # by the reader to mean all
-        rows, sortind = self._extract_rows(rows)
-
-        # this is the full dtype for all columns
-        dtype, offsets, isvar = self.get_rec_dtype(
-            colnums=colnums, vstorage=vstorage
-        )
-        array = np.zeros(nrows, dtype=dtype)
-
-        # note reading into existing data
-        (wnotvar,) = np.where(isvar == False)  # noqa
-        if wnotvar.size > 0:
-            for i in wnotvar:
-                colnum = colnums[i]
-                name = array.dtype.names[i]
-                a = array[name].copy()
-                self._FITS.read_column(
-                    self._ext + 1, colnum + 1, a, rows, sortind
+                warnings.warn(
+                    "The keyword arguments '%s' are being ignored! "
+                    "This warning "
+                    "will be an error in a future version of `fitsio`!" % keys,
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
-                array[name] = a
-                del a
 
-        array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
-
-        (wvar,) = np.where(isvar == True)  # noqa
-        if wvar.size > 0:
-            for i in wvar:
-                colnum = colnums[i]
-                name = array.dtype.names[i]
-                dlist = self._FITS.read_var_column_as_list(
-                    self._ext + 1,
-                    colnum + 1,
-                    rows,
-                    sortind,
+            # if columns is None, returns all.  Guaranteed to be
+            # unique and sorted
+            colnums = self._extract_colnums(columns)
+            if isinstance(colnums, int):
+                # scalar sent, don't read as a recarray
+                return self.read_column(
+                    columns,
+                    rows=rows,
+                    vstorage=vstorage,
+                    upper=upper,
+                    lower=lower,
+                    trim_strings=trim_strings,
                 )
-                if isinstance(dlist[0], str) or (
-                    IS_PY3 and isinstance(dlist[0], bytes)
-                ):
-                    is_string = True
-                else:
-                    is_string = False
 
-                if array[name].dtype.descr[0][1][1] == 'O':
-                    # storing in object array
-                    # get references to each, no copy made
-                    for irow, item in enumerate(dlist):
-                        if sortind is not None:
-                            irow = sortind[irow]
-                        if IS_PY3 and isinstance(item, bytes):
-                            item = item.decode('ascii')
-                        array[name][irow] = item
-                else:
-                    for irow, item in enumerate(dlist):
-                        if sortind is not None:
-                            irow = sortind[irow]
-                        if IS_PY3 and isinstance(item, bytes):
-                            item = item.decode('ascii')
-                        if is_string:
+            rows, sortind = self._extract_rows(rows)
+            if rows is None:
+                nrows = self._info['nrows']
+            else:
+                nrows = rows.size
+
+            # if rows is None still returns None, and is correctly interpreted
+            # by the reader to mean all
+            rows, sortind = self._extract_rows(rows)
+
+            # this is the full dtype for all columns
+            dtype, offsets, isvar = self.get_rec_dtype(
+                colnums=colnums, vstorage=vstorage
+            )
+            array = np.zeros(nrows, dtype=dtype)
+
+            # note reading into existing data
+            (wnotvar,) = np.where(isvar == False)  # noqa
+            if wnotvar.size > 0:
+                for i in wnotvar:
+                    colnum = colnums[i]
+                    name = array.dtype.names[i]
+                    a = array[name].copy()
+                    self._FITS.read_column(
+                        self._ext + 1, colnum + 1, a, rows, sortind
+                    )
+                    array[name] = a
+                    del a
+
+            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
+
+            (wvar,) = np.where(isvar == True)  # noqa
+            if wvar.size > 0:
+                for i in wvar:
+                    colnum = colnums[i]
+                    name = array.dtype.names[i]
+                    dlist = self._FITS.read_var_column_as_list(
+                        self._ext + 1,
+                        colnum + 1,
+                        rows,
+                        sortind,
+                    )
+                    if isinstance(dlist[0], str) or (
+                        IS_PY3 and isinstance(dlist[0], bytes)
+                    ):
+                        is_string = True
+                    else:
+                        is_string = False
+
+                    if array[name].dtype.descr[0][1][1] == 'O':
+                        # storing in object array
+                        # get references to each, no copy made
+                        for irow, item in enumerate(dlist):
+                            if sortind is not None:
+                                irow = sortind[irow]
+                            if IS_PY3 and isinstance(item, bytes):
+                                item = item.decode('ascii')
                             array[name][irow] = item
-                        else:
-                            ncopy = len(item)
-                            array[name][irow][0:ncopy] = item[:]
+                    else:
+                        for irow, item in enumerate(dlist):
+                            if sortind is not None:
+                                irow = sortind[irow]
+                            if IS_PY3 and isinstance(item, bytes):
+                                item = item.decode('ascii')
+                            if is_string:
+                                array[name][irow] = item
+                            else:
+                                ncopy = len(item)
+                                array[name][irow][0:ncopy] = item[:]
 
-        if self.lower or lower:
-            _names_to_lower_if_recarray(array)
-        elif self.upper or upper:
-            _names_to_upper_if_recarray(array)
+            if self.lower or lower:
+                _names_to_lower_if_recarray(array)
+            elif self.upper or upper:
+                _names_to_upper_if_recarray(array)
 
-        self._maybe_trim_strings(array, trim_strings=trim_strings)
+            self._maybe_trim_strings(array, trim_strings=trim_strings)
 
-        return array
+            return array
 
     read_ascii = read
 

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -2234,15 +2234,13 @@ class AsciiTableHDU(TableHDU):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
             )
 
-        # if columns is None, returns all.  Guaranteed to be
-        # unique and sorted
+        # if columns is None, returns all.  Guaranteed to be unique and sorted
         colnums = self._extract_colnums(columns)
         if isinstance(colnums, int):
             # scalar sent, don't read as a recarray

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -207,10 +207,9 @@ class TableHDU(HDUBase):
         elif lastrow > self._info['nrows']:
             raise ValueError('lastrow cannot be greater than nrows')
         nrows = lastrow - firstrow
-        with self._lock:
-            return self._FITS.where(
-                self._ext + 1, expression, firstrow + 1, nrows
-            )
+        return self._FITS.where(
+            self._ext + 1, expression, firstrow + 1, nrows
+        )
 
     def write(
         self, data, firstrow=0, columns=None, names=None, slow=False, **keys
@@ -247,8 +246,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -315,8 +313,7 @@ class TableHDU(HDUBase):
                 if not isobj[i]:
                     nonobj_colnums.append(colnums_all[i])
                     if isrec:
-                        # this still leaves possibility of
-                        # f-order sub-arrays..
+                        # this still leaves possibility of f-order sub-arrays..
                         colref = array_to_native(data_list[i], inplace=False)
                     else:
                         colref = array_to_native_c(data_list[i], inplace=False)
@@ -371,8 +368,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -490,8 +486,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! This "
-                "warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -537,8 +532,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -614,8 +608,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -644,6 +637,7 @@ class TableHDU(HDUBase):
                 rows2delete = [3,88,76]
                 fits['mytable'].delete_rows(rows2delete)
         """
+
         if rows is None:
             return
 
@@ -692,6 +686,7 @@ class TableHDU(HDUBase):
             If True, add or remove rows from the front.  Default
             is False
         """
+
         nrows_current = self.get_nrows()
         if nrows == nrows_current:
             return
@@ -774,8 +769,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -843,8 +837,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -959,8 +952,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -1013,8 +1005,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -1132,8 +1123,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,
@@ -1149,8 +1139,7 @@ class TableHDU(HDUBase):
                 trim_strings=trim_strings,
             )
 
-        # if columns is None, returns all.  Guaranteed to be unique and
-        # sorted
+        # if columns is None, returns all.  Guaranteed to be unique and sorted
         colnums = self._extract_colnums(columns)
         if isinstance(colnums, int):
             # scalar sent, don't read as a recarray
@@ -1270,8 +1259,7 @@ class TableHDU(HDUBase):
             import warnings
 
             warnings.warn(
-                "The keyword arguments '%s' are being ignored! "
-                "This warning "
+                "The keyword arguments '%s' are being ignored! This warning "
                 "will be an error in a future version of `fitsio`!" % keys,
                 DeprecationWarning,
                 stacklevel=2,

--- a/fitsio/hdu/table.py
+++ b/fitsio/hdu/table.py
@@ -119,24 +119,21 @@ class TableHDU(HDUBase):
         Call parent method and make sure this is in fact a
         table HDU.  Set some convenience data.
         """
-        with self._lock:
-            super(TableHDU, self)._update_info()
-            if self._info['hdutype'] == IMAGE_HDU:
-                mess = "Extension %s is not a Table HDU" % self.ext
-                raise ValueError(mess)
-            if 'colinfo' in self._info:
-                self._info["colnames"] = [
-                    i['name'] for i in self._info['colinfo']
-                ]
-                self._info["colnames_lower"] = [
-                    i['name'].lower() for i in self._info['colinfo']
-                ]
-                self._info["ncol"] = len(self._info["colnames"])
+        super(TableHDU, self)._update_info()
+        if self._info['hdutype'] == IMAGE_HDU:
+            mess = "Extension %s is not a Table HDU" % self.ext
+            raise ValueError(mess)
+        if 'colinfo' in self._info:
+            self._info["colnames"] = [i['name'] for i in self._info['colinfo']]
+            self._info["colnames_lower"] = [
+                i['name'].lower() for i in self._info['colinfo']
+            ]
+            self._info["ncol"] = len(self._info["colnames"])
 
-            if self._info['hdutype'] == ASCII_TBL:
-                self._table_type_str = 'ascii'
-            else:
-                self._table_type_str = 'binary'
+        if self._info['hdutype'] == ASCII_TBL:
+            self._table_type_str = 'ascii'
+        else:
+            self._table_type_str = 'binary'
 
     def get_nrows(self):
         """
@@ -246,119 +243,110 @@ class TableHDU(HDUBase):
             for debugging.
         """
 
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        isrec = False
+        if isinstance(data, (list, dict)):
+            if isinstance(data, list):
+                data_list = data
+                if columns is not None:
+                    columns_all = columns
+                elif names is not None:
+                    columns_all = names
+                else:
+                    raise ValueError(
+                        "you must send `columns` or `names` "
+                        "with a list of arrays"
+                    )
+            else:
+                columns_all = list(data.keys())
+                data_list = [data[n] for n in columns_all]
+
+            colnums_all = [self._extract_colnum(c) for c in columns_all]
+            names = [self.get_colname(c) for c in colnums_all]
+
+            isobj = np.zeros(len(data_list), dtype=bool)
+            for i in xrange(len(data_list)):
+                isobj[i] = is_object(data_list[i])
+
+        else:
+            if data.dtype.fields is None:
+                raise ValueError(
+                    "You are writing to a table, so I expected "
+                    "an array with fields as input. If you want "
+                    "to write a simple array, you should use "
+                    "write_column to write to a single column, "
+                    "or instead write to an image hdu"
                 )
 
-            isrec = False
-            if isinstance(data, (list, dict)):
-                if isinstance(data, list):
-                    data_list = data
-                    if columns is not None:
-                        columns_all = columns
-                    elif names is not None:
-                        columns_all = names
-                    else:
-                        raise ValueError(
-                            "you must send `columns` or `names` "
-                            "with a list of arrays"
-                        )
-                else:
-                    columns_all = list(data.keys())
-                    data_list = [data[n] for n in columns_all]
+            if data.shape == ():
+                raise ValueError("cannot write data with shape ()")
 
-                colnums_all = [self._extract_colnum(c) for c in columns_all]
-                names = [self.get_colname(c) for c in colnums_all]
+            isrec = True
+            names = data.dtype.names
+            # only write object types (variable-length columns) after
+            # writing the main table
+            isobj = fields_are_object(data)
 
-                isobj = np.zeros(len(data_list), dtype=bool)
-                for i in xrange(len(data_list)):
-                    isobj[i] = is_object(data_list[i])
-
-            else:
-                if data.dtype.fields is None:
-                    raise ValueError(
-                        "You are writing to a table, so I expected "
-                        "an array with fields as input. If you want "
-                        "to write a simple array, you should use "
-                        "write_column to write to a single column, "
-                        "or instead write to an image hdu"
-                    )
-
-                if data.shape == ():
-                    raise ValueError("cannot write data with shape ()")
-
-                isrec = True
-                names = data.dtype.names
-                # only write object types (variable-length columns) after
-                # writing the main table
-                isobj = fields_are_object(data)
-
-                data_list = []
-                colnums_all = []
-                for i, name in enumerate(names):
-                    colnum = self._extract_colnum(name)
-                    data_list.append(data[name])
-                    colnums_all.append(colnum)
-
-            if slow:
-                for i, name in enumerate(names):
-                    if not isobj[i]:
-                        self.write_column(
-                            name, data_list[i], firstrow=firstrow
-                        )
-            else:
-                nonobj_colnums = []
-                nonobj_arrays = []
-                for i in xrange(len(data_list)):
-                    if not isobj[i]:
-                        nonobj_colnums.append(colnums_all[i])
-                        if isrec:
-                            # this still leaves possibility of
-                            # f-order sub-arrays..
-                            colref = array_to_native(
-                                data_list[i], inplace=False
-                            )
-                        else:
-                            colref = array_to_native_c(
-                                data_list[i], inplace=False
-                            )
-
-                        if IS_PY3 and colref.dtype.char == 'U':
-                            # for python3, we convert unicode to ascii
-                            # this will error if the character is not in ascii
-                            colref = colref.astype('S', copy=copy_if_needed)
-
-                        nonobj_arrays.append(colref)
-
-                for tcolnum, tdata in zip(nonobj_colnums, nonobj_arrays):
-                    self._verify_column_data(tcolnum, tdata)
-
-                if len(nonobj_arrays) > 0:
-                    self._FITS.write_columns(
-                        self._ext + 1,
-                        nonobj_colnums,
-                        nonobj_arrays,
-                        firstrow=firstrow + 1,
-                        write_bitcols=self.write_bitcols,
-                    )
-
-            # writing the object arrays always occurs the same way
-            # need to make sure this works for array fields
+            data_list = []
+            colnums_all = []
             for i, name in enumerate(names):
-                if isobj[i]:
-                    self.write_var_column(
-                        name, data_list[i], firstrow=firstrow
-                    )
+                colnum = self._extract_colnum(name)
+                data_list.append(data[name])
+                colnums_all.append(colnum)
 
-            self._cached_info = None  # invalidate info cache
+        if slow:
+            for i, name in enumerate(names):
+                if not isobj[i]:
+                    self.write_column(name, data_list[i], firstrow=firstrow)
+        else:
+            nonobj_colnums = []
+            nonobj_arrays = []
+            for i in xrange(len(data_list)):
+                if not isobj[i]:
+                    nonobj_colnums.append(colnums_all[i])
+                    if isrec:
+                        # this still leaves possibility of
+                        # f-order sub-arrays..
+                        colref = array_to_native(data_list[i], inplace=False)
+                    else:
+                        colref = array_to_native_c(data_list[i], inplace=False)
+
+                    if IS_PY3 and colref.dtype.char == 'U':
+                        # for python3, we convert unicode to ascii
+                        # this will error if the character is not in ascii
+                        colref = colref.astype('S', copy=copy_if_needed)
+
+                    nonobj_arrays.append(colref)
+
+            for tcolnum, tdata in zip(nonobj_colnums, nonobj_arrays):
+                self._verify_column_data(tcolnum, tdata)
+
+            if len(nonobj_arrays) > 0:
+                self._FITS.write_columns(
+                    self._ext + 1,
+                    nonobj_colnums,
+                    nonobj_arrays,
+                    firstrow=firstrow + 1,
+                    write_bitcols=self.write_bitcols,
+                )
+
+        # writing the object arrays always occurs the same way
+        # need to make sure this works for array fields
+        for i, name in enumerate(names):
+            if isobj[i]:
+                self.write_var_column(name, data_list[i], firstrow=firstrow)
+
+        self._cached_info = None  # invalidate info cache
 
     def write_column(self, column, data, firstrow=0, **keys):
         """
@@ -379,51 +367,50 @@ class TableHDU(HDUBase):
             are doing!  For appending see the append() method.  Default 0.
         """
 
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            colnum = self._extract_colnum(column)
-
-            # need it to be contiguous and native byte order.  For now, make a
-            # copy.  but we may be able to avoid this with some care.
-
-            if not data.flags['C_CONTIGUOUS']:
-                # this always makes a copy
-                data_send = np.ascontiguousarray(data)
-                # this is a copy, we can make sure it is native
-                # and modify in place if needed
-                data_send = array_to_native(data_send, inplace=True)
-            else:
-                # we can avoid the copy with a try-finally block and
-                # some logic
-                data_send = array_to_native(data, inplace=False)
-
-            if IS_PY3 and data_send.dtype.char == 'U':
-                # for python3, we convert unicode to ascii
-                # this will error if the character is not in ascii
-                data_send = data_send.astype('S', copy=copy_if_needed)
-
-            self._verify_column_data(colnum, data_send)
-
-            self._FITS.write_columns(
-                self._ext + 1,
-                [colnum],
-                [data_send],
-                firstrow=firstrow + 1,
-                write_bitcols=self.write_bitcols,
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
-            del data_send
-            self._cached_info = None  # invalidate info cache
+        colnum = self._extract_colnum(column)
+
+        # need it to be contiguous and native byte order.  For now, make a
+        # copy.  but we may be able to avoid this with some care.
+
+        if not data.flags['C_CONTIGUOUS']:
+            # this always makes a copy
+            data_send = np.ascontiguousarray(data)
+            # this is a copy, we can make sure it is native
+            # and modify in place if needed
+            data_send = array_to_native(data_send, inplace=True)
+        else:
+            # we can avoid the copy with a try-finally block and
+            # some logic
+            data_send = array_to_native(data, inplace=False)
+
+        if IS_PY3 and data_send.dtype.char == 'U':
+            # for python3, we convert unicode to ascii
+            # this will error if the character is not in ascii
+            data_send = data_send.astype('S', copy=copy_if_needed)
+
+        self._verify_column_data(colnum, data_send)
+
+        self._FITS.write_columns(
+            self._ext + 1,
+            [colnum],
+            [data_send],
+            firstrow=firstrow + 1,
+            write_bitcols=self.write_bitcols,
+        )
+
+        del data_send
+        self._cached_info = None  # invalidate info cache
 
     def _verify_column_data(self, colnum, data):
         """
@@ -499,29 +486,27 @@ class TableHDU(HDUBase):
             are doing!  For appending see the append() method.  Default 0.
         """
 
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! This "
-                    "warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            if not is_object(data):
-                raise ValueError(
-                    "Only object fields can be written to variable-length "
-                    "arrays"
-                )
-            colnum = self._extract_colnum(column)
-
-            self._FITS.write_var_column(
-                self._ext + 1, colnum + 1, data, firstrow=firstrow + 1
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! This "
+                "warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
-            self._cached_info = None  # invalidate info cache
+
+        if not is_object(data):
+            raise ValueError(
+                "Only object fields can be written to variable-length arrays"
+            )
+        colnum = self._extract_colnum(column)
+
+        self._FITS.write_var_column(
+            self._ext + 1, colnum + 1, data, firstrow=firstrow + 1
+        )
+        self._cached_info = None  # invalidate info cache
 
     def insert_column(
         self, name, data, colnum=None, write_bitcols=None, **keys
@@ -548,66 +533,62 @@ class TableHDU(HDUBase):
         This method is used un-modified by ascii tables as well.
         """
 
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            if write_bitcols is None:
-                write_bitcols = self.write_bitcols
-
-            if name in self._info["colnames"]:
-                raise ValueError("column '%s' already exists" % name)
-
-            if IS_PY3 and data.dtype.char == 'U':
-                # fast dtype conversion using an empty array
-                # we could hack at the actual text description, but using
-                # the numpy API is probably safer
-                # this also avoids doing a dtype conversion on every array
-                # element which could b expensive
-                descr = np.empty(1).astype(data.dtype).astype('S').dtype.descr
-            else:
-                descr = data.dtype.descr
-
-            if len(descr) > 1:
-                raise ValueError(
-                    "you can only insert a single column, requested: %s"
-                    % descr
-                )
-
-            this_descr = descr[0]
-            this_descr = [name, this_descr[1]]
-            if len(data.shape) > 1:
-                this_descr += [data.shape[1:]]
-            this_descr = tuple(this_descr)
-
-            name, fmt, dims = _npy2fits(
-                this_descr,
-                table_type=self._table_type_str,
-                write_bitcols=write_bitcols,
-            )
-            if dims is not None:
-                dims = [dims]
-
-            if colnum is None:
-                new_colnum = len(self._info['colinfo']) + 1
-            else:
-                new_colnum = colnum + 1
-
-            self._FITS.insert_col(
-                self._ext + 1, new_colnum, name, fmt, tdim=dims
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
-            self._cached_info = None  # invalidate info cache
+        if write_bitcols is None:
+            write_bitcols = self.write_bitcols
 
-            self.write_column(name, data)
+        if name in self._info["colnames"]:
+            raise ValueError("column '%s' already exists" % name)
+
+        if IS_PY3 and data.dtype.char == 'U':
+            # fast dtype conversion using an empty array
+            # we could hack at the actual text description, but using
+            # the numpy API is probably safer
+            # this also avoids doing a dtype conversion on every array
+            # element which could b expensive
+            descr = np.empty(1).astype(data.dtype).astype('S').dtype.descr
+        else:
+            descr = data.dtype.descr
+
+        if len(descr) > 1:
+            raise ValueError(
+                "you can only insert a single column, requested: %s" % descr
+            )
+
+        this_descr = descr[0]
+        this_descr = [name, this_descr[1]]
+        if len(data.shape) > 1:
+            this_descr += [data.shape[1:]]
+        this_descr = tuple(this_descr)
+
+        name, fmt, dims = _npy2fits(
+            this_descr,
+            table_type=self._table_type_str,
+            write_bitcols=write_bitcols,
+        )
+        if dims is not None:
+            dims = [dims]
+
+        if colnum is None:
+            new_colnum = len(self._info['colinfo']) + 1
+        else:
+            new_colnum = colnum + 1
+
+        self._FITS.insert_col(self._ext + 1, new_colnum, name, fmt, tdim=dims)
+
+        self._cached_info = None  # invalidate info cache
+
+        self.write_column(name, data)
 
     def append(self, data, columns=None, names=None, **keys):
         """
@@ -629,20 +610,19 @@ class TableHDU(HDUBase):
             of names or column numbers. You can also use the `columns` keyword
             argument.
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
-            firstrow = self._info['nrows']
-            self.write(data, firstrow=firstrow, columns=columns, names=names)
+        firstrow = self._info['nrows']
+        self.write(data, firstrow=firstrow, columns=columns, names=names)
 
     def delete_rows(self, rows):
         """
@@ -664,38 +644,35 @@ class TableHDU(HDUBase):
                 rows2delete = [3,88,76]
                 fits['mytable'].delete_rows(rows2delete)
         """
-        with self._lock:
-            if rows is None:
-                return
+        if rows is None:
+            return
 
-            # extract and convert to 1-offset for C routine
-            if isinstance(rows, slice):
-                rows = self._process_slice(rows)
-                if rows.step is not None and rows.step != 1:
-                    rows = np.arange(
-                        rows.start + 1,
-                        rows.stop + 1,
-                        rows.step,
-                    )
-                else:
-                    # rows must be 1-offset
-                    rows = slice(rows.start + 1, rows.stop + 1)
-            else:
-                rows, sortind = self._extract_rows(rows, sort=True)
-                # rows must be 1-offset
-                rows += 1
-
-            if isinstance(rows, slice):
-                self._FITS.delete_row_range(
-                    self._ext + 1, rows.start, rows.stop
+        # extract and convert to 1-offset for C routine
+        if isinstance(rows, slice):
+            rows = self._process_slice(rows)
+            if rows.step is not None and rows.step != 1:
+                rows = np.arange(
+                    rows.start + 1,
+                    rows.stop + 1,
+                    rows.step,
                 )
             else:
-                if rows.size == 0:
-                    return
+                # rows must be 1-offset
+                rows = slice(rows.start + 1, rows.stop + 1)
+        else:
+            rows, sortind = self._extract_rows(rows, sort=True)
+            # rows must be 1-offset
+            rows += 1
 
-                self._FITS.delete_rows(self._ext + 1, rows)
+        if isinstance(rows, slice):
+            self._FITS.delete_row_range(self._ext + 1, rows.start, rows.stop)
+        else:
+            if rows.size == 0:
+                return
 
-            self._cached_info = None  # invalidate info cache
+            self._FITS.delete_rows(self._ext + 1, rows)
+
+        self._cached_info = None  # invalidate info cache
 
     def resize(self, nrows, front=False):
         """
@@ -715,33 +692,32 @@ class TableHDU(HDUBase):
             If True, add or remove rows from the front.  Default
             is False
         """
-        with self._lock:
-            nrows_current = self.get_nrows()
-            if nrows == nrows_current:
-                return
+        nrows_current = self.get_nrows()
+        if nrows == nrows_current:
+            return
 
-            if nrows < nrows_current:
-                rowdiff = nrows_current - nrows
-                if front:
-                    # delete from the front
-                    start = 0
-                    stop = rowdiff
-                else:
-                    # delete from the back
-                    start = nrows
-                    stop = nrows_current
-
-                self.delete_rows(slice(start, stop))
+        if nrows < nrows_current:
+            rowdiff = nrows_current - nrows
+            if front:
+                # delete from the front
+                start = 0
+                stop = rowdiff
             else:
-                rowdiff = nrows - nrows_current
-                if front:
-                    # in this case zero is what we want, since the code inserts
-                    firstrow = 0
-                else:
-                    firstrow = nrows_current
-                self._FITS.insert_rows(self._ext + 1, firstrow, rowdiff)
+                # delete from the back
+                start = nrows
+                stop = nrows_current
 
-            self._cached_info = None  # invalidate info cache
+            self.delete_rows(slice(start, stop))
+        else:
+            rowdiff = nrows - nrows_current
+            if front:
+                # in this case zero is what we want, since the code inserts
+                firstrow = 0
+            else:
+                firstrow = nrows_current
+            self._FITS.insert_rows(self._ext + 1, firstrow, rowdiff)
+
+        self._cached_info = None  # invalidate info cache
 
     def read(
         self,
@@ -794,46 +770,45 @@ class TableHDU(HDUBase):
             trim_strings= keyword from constructor.
         """
 
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
-            if columns is not None:
-                data = self.read_columns(
-                    columns,
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
-            elif rows is not None:
-                # combinations of row and column subsets are covered by
-                # read_columns so we pass colnums=None here to get all columns
-                data = self.read_rows(
-                    rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
-            else:
-                data = self._read_all(
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
+        if columns is not None:
+            data = self.read_columns(
+                columns,
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+        elif rows is not None:
+            # combinations of row and column subsets are covered by
+            # read_columns so we pass colnums=None here to get all columns
+            data = self.read_rows(
+                rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+        else:
+            data = self._read_all(
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
 
-            return data
+        return data
 
     def _read_all(
         self,
@@ -864,80 +839,77 @@ class TableHDU(HDUBase):
         colnums: integer array, optional
             The column numbers, 0 offset
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            dtype, offsets, isvar = self.get_rec_dtype(
-                colnums=colnums, vstorage=vstorage
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
-            (w,) = np.where(isvar == True)  # noqa
-            has_tbit = self._check_tbit()
+        dtype, offsets, isvar = self.get_rec_dtype(
+            colnums=colnums, vstorage=vstorage
+        )
 
-            if w.size > 0:
-                if vstorage is None:
-                    _vstorage = self._vstorage
-                else:
-                    _vstorage = vstorage
-                colnums = self._extract_colnums()
-                rows = None
-                sortind = None
-                array = self._read_rec_with_var(
-                    colnums,
-                    rows,
-                    sortind,
-                    dtype,
-                    offsets,
-                    isvar,
-                    _vstorage,
-                )
-            elif has_tbit:
-                # drop down to read_columns since we can't stuff into a
-                # contiguous array
-                colnums = self._extract_colnums()
-                array = self.read_columns(
-                    colnums,
-                    rows=None,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
+        (w,) = np.where(isvar == True)  # noqa
+        has_tbit = self._check_tbit()
+
+        if w.size > 0:
+            if vstorage is None:
+                _vstorage = self._vstorage
             else:
-                firstrow = 1  # noqa - not used?
-                nrows = self._info['nrows']
-                array = np.zeros(nrows, dtype=dtype)
+                _vstorage = vstorage
+            colnums = self._extract_colnums()
+            rows = None
+            sortind = None
+            array = self._read_rec_with_var(
+                colnums,
+                rows,
+                sortind,
+                dtype,
+                offsets,
+                isvar,
+                _vstorage,
+            )
+        elif has_tbit:
+            # drop down to read_columns since we can't stuff into a
+            # contiguous array
+            colnums = self._extract_colnums()
+            array = self.read_columns(
+                colnums,
+                rows=None,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+        else:
+            firstrow = 1  # noqa - not used?
+            nrows = self._info['nrows']
+            array = np.zeros(nrows, dtype=dtype)
 
-                self._FITS.read_as_rec(self._ext + 1, 1, nrows, array)
+            self._FITS.read_as_rec(self._ext + 1, 1, nrows, array)
 
-                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
-                    array
+            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
+
+            for colnum, name in enumerate(array.dtype.names):
+                self._rescale_and_convert_field_inplace(
+                    array,
+                    name,
+                    self._info['colinfo'][colnum]['tscale'],
+                    self._info['colinfo'][colnum]['tzero'],
                 )
 
-                for colnum, name in enumerate(array.dtype.names):
-                    self._rescale_and_convert_field_inplace(
-                        array,
-                        name,
-                        self._info['colinfo'][colnum]['tscale'],
-                        self._info['colinfo'][colnum]['tzero'],
-                    )
+        if self.lower or lower:
+            _names_to_lower_if_recarray(array)
+        elif self.upper or upper:
+            _names_to_upper_if_recarray(array)
 
-            if self.lower or lower:
-                _names_to_lower_if_recarray(array)
-            elif self.upper or upper:
-                _names_to_upper_if_recarray(array)
-
-            self._maybe_trim_strings(array, trim_strings=trim_strings)
-            return array
+        self._maybe_trim_strings(array, trim_strings=trim_strings)
+        return array
 
     def read_column(
         self,
@@ -983,31 +955,30 @@ class TableHDU(HDUBase):
             trim_strings= keyword from constructor.
         """
 
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            res = self.read_columns(
-                [col],
-                rows=rows,
-                vstorage=vstorage,
-                upper=upper,
-                lower=lower,
-                trim_strings=trim_strings,
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
-            colname = res.dtype.names[0]
-            data = res[colname]
 
-            self._maybe_trim_strings(data, trim_strings=trim_strings)
-            return data
+        res = self.read_columns(
+            [col],
+            rows=rows,
+            vstorage=vstorage,
+            upper=upper,
+            lower=lower,
+            trim_strings=trim_strings,
+        )
+        colname = res.dtype.names[0]
+        data = res[colname]
+
+        self._maybe_trim_strings(data, trim_strings=trim_strings)
+        return data
 
     def read_rows(
         self,
@@ -1038,90 +1009,85 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
-            if rows is None:
-                # we actually want all rows!
-                return self._read_all()
+        if rows is None:
+            # we actually want all rows!
+            return self._read_all()
 
-            if self._info['hdutype'] == ASCII_TBL:
-                return self.read(
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
+        if self._info['hdutype'] == ASCII_TBL:
+            return self.read(
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
 
-            rows, sortind = self._extract_rows(rows)
-            dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
+        rows, sortind = self._extract_rows(rows)
+        dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
 
-            (w,) = np.where(isvar == True)  # noqa
-            has_tbit = self._check_tbit()
+        (w,) = np.where(isvar == True)  # noqa
+        has_tbit = self._check_tbit()
 
-            if w.size > 0:
-                if vstorage is None:
-                    _vstorage = self._vstorage
-                else:
-                    _vstorage = vstorage
-                colnums = self._extract_colnums()
-                return self._read_rec_with_var(
-                    colnums,
-                    rows,
-                    sortind,
-                    dtype,
-                    offsets,
-                    isvar,
-                    _vstorage,
-                )
-            elif has_tbit:
-                # drop down to read_columns since we can't stuff into a
-                # contiguous array
-                colnums = self._extract_colnums()
-                array = self.read_columns(
-                    colnums,
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
+        if w.size > 0:
+            if vstorage is None:
+                _vstorage = self._vstorage
             else:
-                array = np.zeros(rows.size, dtype=dtype)
-                self._FITS.read_rows_as_rec(
-                    self._ext + 1, array, rows, sortind
+                _vstorage = vstorage
+            colnums = self._extract_colnums()
+            return self._read_rec_with_var(
+                colnums,
+                rows,
+                sortind,
+                dtype,
+                offsets,
+                isvar,
+                _vstorage,
+            )
+        elif has_tbit:
+            # drop down to read_columns since we can't stuff into a
+            # contiguous array
+            colnums = self._extract_colnums()
+            array = self.read_columns(
+                colnums,
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+        else:
+            array = np.zeros(rows.size, dtype=dtype)
+            self._FITS.read_rows_as_rec(self._ext + 1, array, rows, sortind)
+
+            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
+
+            for colnum, name in enumerate(array.dtype.names):
+                self._rescale_and_convert_field_inplace(
+                    array,
+                    name,
+                    self._info['colinfo'][colnum]['tscale'],
+                    self._info['colinfo'][colnum]['tzero'],
                 )
 
-                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
-                    array
-                )
+        if self.lower or lower:
+            _names_to_lower_if_recarray(array)
+        elif self.upper or upper:
+            _names_to_upper_if_recarray(array)
 
-                for colnum, name in enumerate(array.dtype.names):
-                    self._rescale_and_convert_field_inplace(
-                        array,
-                        name,
-                        self._info['colinfo'][colnum]['tscale'],
-                        self._info['colinfo'][colnum]['tzero'],
-                    )
+        self._maybe_trim_strings(array, trim_strings=trim_strings)
 
-            if self.lower or lower:
-                _names_to_lower_if_recarray(array)
-            elif self.upper or upper:
-                _names_to_upper_if_recarray(array)
-
-            self._maybe_trim_strings(array, trim_strings=trim_strings)
-
-            return array
+        return array
 
     def read_columns(
         self,
@@ -1162,105 +1128,102 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            if self._info['hdutype'] == ASCII_TBL:
-                return self.read(
-                    columns=columns,
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
-
-            # if columns is None, returns all.  Guaranteed to be unique and
-            # sorted
-            colnums = self._extract_colnums(columns)
-            if isinstance(colnums, int):
-                # scalar sent, don't read as a recarray
-                return self.read_column(
-                    columns,
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
-
-            # if rows is None still returns None, and is correctly interpreted
-            # by the reader to mean all
-            rows, sortind = self._extract_rows(rows)
-
-            # this is the full dtype for all columns
-            dtype, offsets, isvar = self.get_rec_dtype(
-                colnums=colnums, vstorage=vstorage
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
-            (w,) = np.where(isvar == True)  # noqa
-            if w.size > 0:
-                if vstorage is None:
-                    _vstorage = self._vstorage
-                else:
-                    _vstorage = vstorage
-                array = self._read_rec_with_var(
-                    colnums,
-                    rows,
-                    sortind,
-                    dtype,
-                    offsets,
-                    isvar,
-                    _vstorage,
-                )
+        if self._info['hdutype'] == ASCII_TBL:
+            return self.read(
+                columns=columns,
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+
+        # if columns is None, returns all.  Guaranteed to be unique and
+        # sorted
+        colnums = self._extract_colnums(columns)
+        if isinstance(colnums, int):
+            # scalar sent, don't read as a recarray
+            return self.read_column(
+                columns,
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+
+        # if rows is None still returns None, and is correctly interpreted
+        # by the reader to mean all
+        rows, sortind = self._extract_rows(rows)
+
+        # this is the full dtype for all columns
+        dtype, offsets, isvar = self.get_rec_dtype(
+            colnums=colnums, vstorage=vstorage
+        )
+
+        (w,) = np.where(isvar == True)  # noqa
+        if w.size > 0:
+            if vstorage is None:
+                _vstorage = self._vstorage
             else:
-                if rows is None:
-                    nrows = self._info['nrows']
-                else:
-                    nrows = rows.size
+                _vstorage = vstorage
+            array = self._read_rec_with_var(
+                colnums,
+                rows,
+                sortind,
+                dtype,
+                offsets,
+                isvar,
+                _vstorage,
+            )
+        else:
+            if rows is None:
+                nrows = self._info['nrows']
+            else:
+                nrows = rows.size
 
-                array = np.zeros(nrows, dtype=dtype)
+            array = np.zeros(nrows, dtype=dtype)
 
-                colnumsp = colnums[:].copy()
-                colnumsp[:] += 1
-                self._FITS.read_columns_as_rec(
-                    self._ext + 1, colnumsp, array, rows, sortind
+            colnumsp = colnums[:].copy()
+            colnumsp[:] += 1
+            self._FITS.read_columns_as_rec(
+                self._ext + 1, colnumsp, array, rows, sortind
+            )
+
+            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
+
+            for i in xrange(colnums.size):
+                colnum = int(colnums[i])
+                name = array.dtype.names[i]
+                self._rescale_and_convert_field_inplace(
+                    array,
+                    name,
+                    self._info['colinfo'][colnum]['tscale'],
+                    self._info['colinfo'][colnum]['tzero'],
                 )
 
-                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
-                    array
-                )
+        if self._check_tbit(colnums=colnums):
+            array = self._fix_tbit_dtype(array, colnums)
 
-                for i in xrange(colnums.size):
-                    colnum = int(colnums[i])
-                    name = array.dtype.names[i]
-                    self._rescale_and_convert_field_inplace(
-                        array,
-                        name,
-                        self._info['colinfo'][colnum]['tscale'],
-                        self._info['colinfo'][colnum]['tzero'],
-                    )
+        if self.lower or lower:
+            _names_to_lower_if_recarray(array)
+        elif self.upper or upper:
+            _names_to_upper_if_recarray(array)
 
-            if self._check_tbit(colnums=colnums):
-                array = self._fix_tbit_dtype(array, colnums)
+        self._maybe_trim_strings(array, trim_strings=trim_strings)
 
-            if self.lower or lower:
-                _names_to_lower_if_recarray(array)
-            elif self.upper or upper:
-                _names_to_upper_if_recarray(array)
-
-            self._maybe_trim_strings(array, trim_strings=trim_strings)
-
-            return array
+        return array
 
     def read_slice(
         self,
@@ -1303,103 +1266,100 @@ class TableHDU(HDUBase):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
-            if self._info['hdutype'] == ASCII_TBL:
-                rows = np.arange(firstrow, lastrow, step, dtype='i8')
-                return self.read_ascii(
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
+        if self._info['hdutype'] == ASCII_TBL:
+            rows = np.arange(firstrow, lastrow, step, dtype='i8')
+            return self.read_ascii(
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
 
-            if self._info['hdutype'] == IMAGE_HDU:
-                raise ValueError("slices currently only supported for tables")
+        if self._info['hdutype'] == IMAGE_HDU:
+            raise ValueError("slices currently only supported for tables")
 
-            maxrow = self._info['nrows']
-            if firstrow < 0 or lastrow > maxrow:
-                raise ValueError(
-                    "slice must specify a sub-range of [%d,%d]" % (0, maxrow)
-                )
+        maxrow = self._info['nrows']
+        if firstrow < 0 or lastrow > maxrow:
+            raise ValueError(
+                "slice must specify a sub-range of [%d,%d]" % (0, maxrow)
+            )
 
-            dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
+        dtype, offsets, isvar = self.get_rec_dtype(vstorage=vstorage)
 
-            (w,) = np.where(isvar == True)  # noqa
-            has_tbit = self._check_tbit()
+        (w,) = np.where(isvar == True)  # noqa
+        has_tbit = self._check_tbit()
 
-            if w.size > 0:
-                if vstorage is None:
-                    _vstorage = self._vstorage
-                else:
-                    _vstorage = vstorage
-                rows = np.arange(firstrow, lastrow, step, dtype='i8')
-                sortind = np.arange(rows.size, dtype='i8')
-                colnums = self._extract_colnums()
-                array = self._read_rec_with_var(
-                    colnums, rows, sortind, dtype, offsets, isvar, _vstorage
-                )
-            elif has_tbit:
-                # drop down to read_columns since we can't stuff into a
-                # contiguous array
-                colnums = self._extract_colnums()
-                rows = np.arange(firstrow, lastrow, step, dtype='i8')
-                array = self.read_columns(
-                    colnums,
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
+        if w.size > 0:
+            if vstorage is None:
+                _vstorage = self._vstorage
             else:
-                if step != 1:
-                    rows = np.arange(firstrow, lastrow, step, dtype='i8')
-                    array = self.read(rows=rows)
-                else:
-                    # no +1 because lastrow is non-inclusive
-                    nrows = lastrow - firstrow
-                    array = np.zeros(nrows, dtype=dtype)
+                _vstorage = vstorage
+            rows = np.arange(firstrow, lastrow, step, dtype='i8')
+            sortind = np.arange(rows.size, dtype='i8')
+            colnums = self._extract_colnums()
+            array = self._read_rec_with_var(
+                colnums, rows, sortind, dtype, offsets, isvar, _vstorage
+            )
+        elif has_tbit:
+            # drop down to read_columns since we can't stuff into a
+            # contiguous array
+            colnums = self._extract_colnums()
+            rows = np.arange(firstrow, lastrow, step, dtype='i8')
+            array = self.read_columns(
+                colnums,
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
+        else:
+            if step != 1:
+                rows = np.arange(firstrow, lastrow, step, dtype='i8')
+                array = self.read(rows=rows)
+            else:
+                # no +1 because lastrow is non-inclusive
+                nrows = lastrow - firstrow
+                array = np.zeros(nrows, dtype=dtype)
 
-                    # only first needs to be +1.  This is becuase the c code is
-                    # inclusive
-                    self._FITS.read_as_rec(
-                        self._ext + 1, firstrow + 1, lastrow, array
+                # only first needs to be +1.  This is becuase the c code is
+                # inclusive
+                self._FITS.read_as_rec(
+                    self._ext + 1, firstrow + 1, lastrow, array
+                )
+
+                array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(
+                    array
+                )
+
+                for colnum, name in enumerate(array.dtype.names):
+                    self._rescale_and_convert_field_inplace(
+                        array,
+                        name,
+                        self._info['colinfo'][colnum]['tscale'],
+                        self._info['colinfo'][colnum]['tzero'],
                     )
 
-                    array = (
-                        self._maybe_decode_fits_ascii_strings_to_unicode_py3(
-                            array
-                        )
-                    )
+        if self.lower or lower:
+            _names_to_lower_if_recarray(array)
+        elif self.upper or upper:
+            _names_to_upper_if_recarray(array)
 
-                    for colnum, name in enumerate(array.dtype.names):
-                        self._rescale_and_convert_field_inplace(
-                            array,
-                            name,
-                            self._info['colinfo'][colnum]['tscale'],
-                            self._info['colinfo'][colnum]['tzero'],
-                        )
+        self._maybe_trim_strings(array, trim_strings=trim_strings)
 
-            if self.lower or lower:
-                _names_to_lower_if_recarray(array)
-            elif self.upper or upper:
-                _names_to_upper_if_recarray(array)
-
-            self._maybe_trim_strings(array, trim_strings=trim_strings)
-
-            return array
+        return array
 
     def get_rec_dtype(self, colnums=None, vstorage=None, **keys):
         """
@@ -2282,110 +2242,109 @@ class AsciiTableHDU(TableHDU):
             If True, trim trailing spaces from strings. Will over-ride the
             trim_strings= keyword from constructor.
         """
-        with self._lock:
-            if keys:
-                import warnings
+        if keys:
+            import warnings
 
-                warnings.warn(
-                    "The keyword arguments '%s' are being ignored! "
-                    "This warning "
-                    "will be an error in a future version of `fitsio`!" % keys,
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            # if columns is None, returns all.  Guaranteed to be
-            # unique and sorted
-            colnums = self._extract_colnums(columns)
-            if isinstance(colnums, int):
-                # scalar sent, don't read as a recarray
-                return self.read_column(
-                    columns,
-                    rows=rows,
-                    vstorage=vstorage,
-                    upper=upper,
-                    lower=lower,
-                    trim_strings=trim_strings,
-                )
-
-            rows, sortind = self._extract_rows(rows)
-            if rows is None:
-                nrows = self._info['nrows']
-            else:
-                nrows = rows.size
-
-            # if rows is None still returns None, and is correctly interpreted
-            # by the reader to mean all
-            rows, sortind = self._extract_rows(rows)
-
-            # this is the full dtype for all columns
-            dtype, offsets, isvar = self.get_rec_dtype(
-                colnums=colnums, vstorage=vstorage
+            warnings.warn(
+                "The keyword arguments '%s' are being ignored! "
+                "This warning "
+                "will be an error in a future version of `fitsio`!" % keys,
+                DeprecationWarning,
+                stacklevel=2,
             )
-            array = np.zeros(nrows, dtype=dtype)
 
-            # note reading into existing data
-            (wnotvar,) = np.where(isvar == False)  # noqa
-            if wnotvar.size > 0:
-                for i in wnotvar:
-                    colnum = colnums[i]
-                    name = array.dtype.names[i]
-                    a = array[name].copy()
-                    self._FITS.read_column(
-                        self._ext + 1, colnum + 1, a, rows, sortind
-                    )
-                    array[name] = a
-                    del a
+        # if columns is None, returns all.  Guaranteed to be
+        # unique and sorted
+        colnums = self._extract_colnums(columns)
+        if isinstance(colnums, int):
+            # scalar sent, don't read as a recarray
+            return self.read_column(
+                columns,
+                rows=rows,
+                vstorage=vstorage,
+                upper=upper,
+                lower=lower,
+                trim_strings=trim_strings,
+            )
 
-            array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
+        rows, sortind = self._extract_rows(rows)
+        if rows is None:
+            nrows = self._info['nrows']
+        else:
+            nrows = rows.size
 
-            (wvar,) = np.where(isvar == True)  # noqa
-            if wvar.size > 0:
-                for i in wvar:
-                    colnum = colnums[i]
-                    name = array.dtype.names[i]
-                    dlist = self._FITS.read_var_column_as_list(
-                        self._ext + 1,
-                        colnum + 1,
-                        rows,
-                        sortind,
-                    )
-                    if isinstance(dlist[0], str) or (
-                        IS_PY3 and isinstance(dlist[0], bytes)
-                    ):
-                        is_string = True
-                    else:
-                        is_string = False
+        # if rows is None still returns None, and is correctly interpreted
+        # by the reader to mean all
+        rows, sortind = self._extract_rows(rows)
 
-                    if array[name].dtype.descr[0][1][1] == 'O':
-                        # storing in object array
-                        # get references to each, no copy made
-                        for irow, item in enumerate(dlist):
-                            if sortind is not None:
-                                irow = sortind[irow]
-                            if IS_PY3 and isinstance(item, bytes):
-                                item = item.decode('ascii')
+        # this is the full dtype for all columns
+        dtype, offsets, isvar = self.get_rec_dtype(
+            colnums=colnums, vstorage=vstorage
+        )
+        array = np.zeros(nrows, dtype=dtype)
+
+        # note reading into existing data
+        (wnotvar,) = np.where(isvar == False)  # noqa
+        if wnotvar.size > 0:
+            for i in wnotvar:
+                colnum = colnums[i]
+                name = array.dtype.names[i]
+                a = array[name].copy()
+                self._FITS.read_column(
+                    self._ext + 1, colnum + 1, a, rows, sortind
+                )
+                array[name] = a
+                del a
+
+        array = self._maybe_decode_fits_ascii_strings_to_unicode_py3(array)
+
+        (wvar,) = np.where(isvar == True)  # noqa
+        if wvar.size > 0:
+            for i in wvar:
+                colnum = colnums[i]
+                name = array.dtype.names[i]
+                dlist = self._FITS.read_var_column_as_list(
+                    self._ext + 1,
+                    colnum + 1,
+                    rows,
+                    sortind,
+                )
+                if isinstance(dlist[0], str) or (
+                    IS_PY3 and isinstance(dlist[0], bytes)
+                ):
+                    is_string = True
+                else:
+                    is_string = False
+
+                if array[name].dtype.descr[0][1][1] == 'O':
+                    # storing in object array
+                    # get references to each, no copy made
+                    for irow, item in enumerate(dlist):
+                        if sortind is not None:
+                            irow = sortind[irow]
+                        if IS_PY3 and isinstance(item, bytes):
+                            item = item.decode('ascii')
+                        array[name][irow] = item
+                else:
+                    for irow, item in enumerate(dlist):
+                        if sortind is not None:
+                            irow = sortind[irow]
+                        if IS_PY3 and isinstance(item, bytes):
+                            item = item.decode('ascii')
+                        if is_string:
                             array[name][irow] = item
-                    else:
-                        for irow, item in enumerate(dlist):
-                            if sortind is not None:
-                                irow = sortind[irow]
-                            if IS_PY3 and isinstance(item, bytes):
-                                item = item.decode('ascii')
-                            if is_string:
-                                array[name][irow] = item
-                            else:
-                                ncopy = len(item)
-                                array[name][irow][0:ncopy] = item[:]
+                        else:
+                            ncopy = len(item)
+                            array[name][irow][0:ncopy] = item[:]
 
-            if self.lower or lower:
-                _names_to_lower_if_recarray(array)
-            elif self.upper or upper:
-                _names_to_upper_if_recarray(array)
+        if self.lower or lower:
+            _names_to_lower_if_recarray(array)
+        elif self.upper or upper:
+            _names_to_upper_if_recarray(array)
 
-            self._maybe_trim_strings(array, trim_strings=trim_strings)
+        self._maybe_trim_strings(array, trim_strings=trim_strings)
 
-            return array
+        return array
 
     read_ascii = read
 

--- a/fitsio/tests/test_locking.py
+++ b/fitsio/tests/test_locking.py
@@ -10,7 +10,7 @@ import uuid
 import fitsio
 
 
-def test_locking_io(thread_index, iteration_index):
+def test_locking_io():
     nt = 10
     rng = np.random.RandomState(seed=10)
     data = rng.normal(size=(100, 100))
@@ -32,11 +32,7 @@ def test_locking_io(thread_index, iteration_index):
     with tempfile.TemporaryDirectory() as tmpdir:
         fname = os.path.join(
             tmpdir,
-            "fname"
-            + str(uuid.uuid4().hex)
-            + str(thread_index)
-            + str(iteration_index)
-            + ".fits",
+            "fname" + str(uuid.uuid4().hex) + ".fits",
         )
 
         with fitsio.FITS(fname, "rw", clobber=True) as fp:
@@ -53,14 +49,6 @@ def test_locking_io(thread_index, iteration_index):
 
         with fitsio.FITS(fname) as fp:
             n_ext = len(fp)
-
-        print(
-            "thread|iter|n_ext:",
-            thread_index,
-            iteration_index,
-            n_ext,
-            flush=True,
-        )
 
         assert n_ext == nt + 1
         if sys.version_info.major < 3 or sys.version_info.minor < 13:

--- a/fitsio/tests/test_locking.py
+++ b/fitsio/tests/test_locking.py
@@ -55,10 +55,3 @@ def test_locking_io():
         print("time:", t0, flush=True)
         print("# of extensions:", n_ext, flush=True)
         assert n_ext == nt + 1
-
-        if sys.version_info.major < 3 or sys.version_info.minor < 13:
-            assert t0 > 2.0
-        else:
-            # locking in the C layer is much more efficient
-            assert t0 > 0.1, t0
-            assert t0 < 2.0, t0

--- a/fitsio/tests/test_locking.py
+++ b/fitsio/tests/test_locking.py
@@ -17,15 +17,17 @@ def test_locking_io():
 
     lock = threading.RLock()
 
-    def _read_file(fp):
+    def _read_file(fp, i):
         # older pythons need a lock
         if sys.version_info.major < 3 or sys.version_info.minor < 13:
             with lock:
                 time.sleep(0.1)
+                fp.reopen()
                 fp.write_image(data)
                 return fp[0].read()
         else:
             time.sleep(0.1)
+            fp.reopen()
             fp.write_image(data)
             return fp[0].read()
 
@@ -41,7 +43,7 @@ def test_locking_io():
         with fitsio.FITS(fname, "rw") as fp:
             t0 = time.time()
             with ThreadPoolExecutor(max_workers=nt) as exc:
-                futs = [exc.submit(_read_file, fp) for _ in range(nt)]
+                futs = [exc.submit(_read_file, fp, i) for i in range(nt)]
                 for fut in futs:
                     res = fut.result()
                     np.testing.assert_array_equal(res, data)
@@ -50,9 +52,13 @@ def test_locking_io():
         with fitsio.FITS(fname) as fp:
             n_ext = len(fp)
 
+        print("time:", t0, flush=True)
+        print("# of extensions:", n_ext, flush=True)
         assert n_ext == nt + 1
+
         if sys.version_info.major < 3 or sys.version_info.minor < 13:
             assert t0 > 1.0
         else:
             # locking in the C layer is much more efficient
-            assert t0 > 0.1
+            assert t0 > 0.1, t0
+            assert t0 < 1.0, t0

--- a/fitsio/tests/test_locking.py
+++ b/fitsio/tests/test_locking.py
@@ -57,8 +57,8 @@ def test_locking_io():
         assert n_ext == nt + 1
 
         if sys.version_info.major < 3 or sys.version_info.minor < 13:
-            assert t0 > 1.0
+            assert t0 > 2.0
         else:
             # locking in the C layer is much more efficient
             assert t0 > 0.1, t0
-            assert t0 < 1.0, t0
+            assert t0 < 2.0, t0

--- a/fitsio/util.py
+++ b/fitsio/util.py
@@ -222,29 +222,25 @@ def _nonfinite_as_cfitsio_floating_null_value(data, target_hdu_compressed):
             data[msk_nonfinite] = old_vals
 
 
-class SynchronizedMeta(type):
-    """A metaclass that automatically wraps all methods with an RLock."""
+def synchronized_class(cls):
+    """A class decorator that wraps all public methods with an RLock."""
+    # Wrap every callable method
+    for key, value in list(cls.__dict__.items()):
+        if callable(value) and key not in [
+            "__init__",
+            "__new__",
+            "__enter__",
+            "__exit__",
+        ]:
 
-    def __new__(cls, name, bases, attrs):
-        # Create a lock bound to the instance, or shared depending on design.
-        # It's safest to wrap functions into locked methods dynamically.
+            def make_locked(func=value):
+                @functools.wraps(func)
+                def wrapper(self, *args, **kwargs):
+                    with self._lock:
+                        return func(self, *args, **kwargs)
 
-        for attr_name, attr_value in list(attrs.items()):
-            # Only wrap callables, ignoring special magic methods like __init__
-            if callable(attr_value) and attr_name not in [
-                "__init__",
-                "__new__",
-                "__enter__",
-                "__exit__",
-            ]:
-                attrs[name] = cls._make_synchronized(attr_value)
-        return super().__new__(cls, name, bases, attrs)
+                return wrapper
 
-    @staticmethod
-    def _make_synchronized(func):
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            with self._lock:
-                return func(self, *args, **kwargs)
+            setattr(cls, key, make_locked())
 
-        return wrapper
+    return cls

--- a/fitsio/util.py
+++ b/fitsio/util.py
@@ -3,6 +3,7 @@ utilities for the fits library
 """
 
 from contextlib import contextmanager
+import functools
 import sys
 import numpy
 
@@ -219,3 +220,31 @@ def _nonfinite_as_cfitsio_floating_null_value(data, target_hdu_compressed):
     finally:
         if has_nonfinite:
             data[msk_nonfinite] = old_vals
+
+
+class SynchronizedMeta(type):
+    """A metaclass that automatically wraps all methods with an RLock."""
+
+    def __new__(cls, name, bases, attrs):
+        # Create a lock bound to the instance, or shared depending on design.
+        # It's safest to wrap functions into locked methods dynamically.
+
+        for attr_name, attr_value in list(attrs.items()):
+            # Only wrap callables, ignoring special magic methods like __init__
+            if callable(attr_value) and attr_name not in [
+                "__init__",
+                "__new__",
+                "__enter__",
+                "__exit__",
+            ]:
+                attrs[name] = cls._make_synchronized(attr_value)
+        return super().__new__(cls, name, bases, attrs)
+
+    @staticmethod
+    def _make_synchronized(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            with self._lock:
+                return func(self, *args, **kwargs)
+
+        return wrapper

--- a/fitsio/util.py
+++ b/fitsio/util.py
@@ -2,7 +2,7 @@
 utilities for the fits library
 """
 
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 import functools
 import sys
 import numpy
@@ -223,10 +223,10 @@ def _nonfinite_as_cfitsio_floating_null_value(data, target_hdu_compressed):
 
 
 def synchronized_class(cls):
-    """A class decorator that wraps all public methods with an RLock."""
+    """A class decorator that wraps all class methods with an RLock."""
 
-    from contextlib import nullcontext
-
+    # ensure the class has some lock even if it does nothing
+    # instances can override
     cls._lock = nullcontext()
 
     # Wrap every callable method

--- a/fitsio/util.py
+++ b/fitsio/util.py
@@ -224,19 +224,29 @@ def _nonfinite_as_cfitsio_floating_null_value(data, target_hdu_compressed):
 
 def synchronized_class(cls):
     """A class decorator that wraps all public methods with an RLock."""
+
+    from contextlib import nullcontext
+
+    cls._lock = nullcontext()
+
     # Wrap every callable method
-    for key, value in list(cls.__dict__.items()):
+    for key in list(dir(cls)):
+        value = getattr(cls, key)
         if callable(value) and key not in [
             "__init__",
+            "__init_subclass__",
             "__new__",
             "__enter__",
             "__exit__",
+            "__class__",
         ]:
+            if key == "__getattribute":
+                value = object.__getattribute__
 
             def make_locked(func=value):
                 @functools.wraps(func)
                 def wrapper(self, *args, **kwargs):
-                    with self._lock:
+                    with object.__getattribute__(self, "_lock"):
                         return func(self, *args, **kwargs)
 
                 return wrapper


### PR DESCRIPTION
In free-threaded builds, I've seen what appear to be race conditions when `FITS` objects are shared across threads. See this test run: https://github.com/esheldon/fitsio/actions/runs/28881711342/job/85671386326?pr=516

This PR adds an RLock to prevent them. I am not sure if we should merge this. Instead, it might be better to simply not support this use case and remove the test that is failing.