### PR TITLE
fix: get threading support correct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes
   underlying cfitsio library was compiled with reentrant support.
 - Added back patch of `cfitsio` to prevent subnormal floats from being
   cast to zero for bundled builds.
-- Updated docs to clarify threaded usage of `FITS` files.
+- Updated docs to clarify threaded usage of `FITS` objects.
 - Removed extra lock in C layer. Users must employ their own locks
   in Python for correct results.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Bug Fixes
 - Marked tests for reproducible lossy float compression as xfail for external
   cfitsio libraries.
 - Skip tests for large compressed images exceeding `2**32` bytes on 32-bit platforms.
-- Removed incorrect test of threaded usage.
+- Fixed incorrect test of threaded usage.
 
 ## 1.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Changes
 - Added back patch of `cfitsio` to prevent subnormal floats from being
   cast to zero for bundled builds.
 - Updated docs to clarify threaded usage of `FITS` files.
+- Removed extra lock in C layer. Users must employ their own locks
+  in Python for correct results.
 
 Bug Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Changes
   underlying cfitsio library was compiled with reentrant support.
 - Added back patch of `cfitsio` to prevent subnormal floats from being
   cast to zero for bundled builds.
+- Updated docs to clarify threaded usage of `FITS` files.
 
 Bug Fixes
 
@@ -19,6 +20,7 @@ Bug Fixes
 - Marked tests for reproducible lossy float compression as xfail for external
   cfitsio libraries.
 - Skip tests for large compressed images exceeding `2**32` bytes on 32-bit platforms.
+- Removed incorrect test of threaded usage.
 
 ## 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -563,7 +563,8 @@ useful resource for learning more about the concepts above.
 To enforce the threading constraints, we use the following macros in the C layer:
 
 - `LOCK_FITS(x)` & `UNLOCK_FITS(x)`: These macros take a pointer to the `PyFITSObject`
-  object, and lock/unlock the underlying FITS file pointer for use by a single thread.
+  object, and for non-reentrant builds, use a global lock to avoid concurrent calls
+  to non-reentrant builds of the `cfitsio` library.
   This lock is not reentrant (i.e., every `LOCK_FITS` call must be paired with an
   `UNLOCK_FITS` call). The implementation of this lock uses the one from the Python C
   API so it will not deadlock with the GIL-related macros below.
@@ -577,12 +578,13 @@ To enforce the threading constraints, we use the following macros in the C layer
   concise. You cannot use this macro in between calls to `RELEASE_GIL` and `CAPTURE_GIL`.
 
 All of these macros (except `NOGIL`) must be followed by a semicolon when used in C code
-(e.g., `ALLOW_NOGIL;`). You must also take care to properly unlock the FITS file pointer
+(e.g., `ALLOW_NOGIL;`). You must also take care to properly unlock the global lock
 and/or release the GIL for all possible execution paths through your function (including
 branches for error handling). C `goto` statements can be very helpful for this task.
 
-In the C wrapper of `cfitsio` on Python 3.13 and above, we always lock the underlying FITS
-file pointer, and we do our best to release the GIL during I/O and/or long-running operations.
+In the C wrapper of `cfitsio` on Python 3.13 and above, we always employ a global lock for
+non-reentrant builds of `cfitsio`, and we do our best to release the GIL during I/O and/or
+long-running operations.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -492,10 +492,8 @@ on multithreaded programs from `cfitsio`. Specifically this means that
   on its own, getting a unique `fitsio.FITS` object.
 - Concurrent writing to FITS files is NOT thread-safe.
 - `fitsio.FITS` file objects can be shared between threads for reading, but only one thread
-  can use the file object at a time. On Python 3.13 or newer, `fitsio` employs a lock on the
-  underlying `cfitsio` data structure to enforce this condition and help prevent race conditions.
-  Even with this lock, you will likely need to employ your own locks from the `threading` module in order
-  to prevent race conditions arising from how the `fitsio` library is being used. See the example below.
+  can use the file object at a time. You will need to employ a lock from the `threading` module in order
+  to prevent race conditions. See the example below.
 
 `fitsio` is compatible with Python free threading, and will not reenable the GIL
 when imported. However, the constraints above must be respected even when using Python

--- a/fitsio/fitsio_pywrap.c
+++ b/fitsio/fitsio_pywrap.c
@@ -45,11 +45,9 @@ for details on how to use these macros.
 #if (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 13)
 #define PYFITS_HAS_LOCK
 #define LOCK_FITS(x)                                                           \
-    (fits_is_reentrant() == 0 ? PyMutex_Lock(&GLOBAL_FITS_LOCK)                \
-                              : PyMutex_Lock(&(x->fits_lock)))
+    (fits_is_reentrant() == 0 ? PyMutex_Lock(&GLOBAL_FITS_LOCK) : (void)NULL)
 #define UNLOCK_FITS(x)                                                         \
-    (fits_is_reentrant() == 0 ? PyMutex_Unlock(&GLOBAL_FITS_LOCK)              \
-                              : PyMutex_Unlock(&(x->fits_lock)))
+    (fits_is_reentrant() == 0 ? PyMutex_Unlock(&GLOBAL_FITS_LOCK) : (void)NULL)
 #define ALLOW_NOGIL                                                            \
     PyThreadState *_save1_ = NULL;                                             \
     int _evaltmp123_
@@ -84,10 +82,6 @@ struct PyFITSObject {
     // messages as they happen. sometimes cfitsio will clear
     // the error stack and this removes important debugging info
     char pyfits_errmsg[PYFITS_ERRMSG_LEN];
-#ifdef PYFITS_HAS_LOCK
-    // lock for cfitsio FITS data when free-threading
-    PyMutex fits_lock;
-#endif
 };
 
 // check unicode for python3, string for python2
@@ -521,10 +515,6 @@ static int PyFITSObject_init(struct PyFITSObject *self, PyObject *args,
     // init the error message to an empty string
     self->pyfits_errmsg[0] = '\0';
     self->fits = NULL;
-
-#ifdef PYFITS_HAS_LOCK
-    memset(&(self->fits_lock), 0, sizeof(PyMutex));
-#endif
 
     if (!PyArg_ParseTuple(args, (char *)"sii", &filename, &mode, &create)) {
         return -1;

--- a/fitsio/tests/test_locking.py
+++ b/fitsio/tests/test_locking.py
@@ -1,16 +1,14 @@
 from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 import os
-import sys
 import threading
 import tempfile
-import time
 import uuid
 
 import fitsio
 
 
-def test_locking_io(thread_index, iteration_index):
+def test_locking_io():
     nt = 10
     rng = np.random.RandomState(seed=10)
     data = rng.normal(size=(100, 100))
@@ -18,53 +16,28 @@ def test_locking_io(thread_index, iteration_index):
     lock = threading.RLock()
 
     def _read_file(fp):
-        # older pythons need a lock
-        if sys.version_info.major < 3 or sys.version_info.minor < 13:
-            with lock:
-                time.sleep(0.1)
-                fp.write_image(data)
-                return fp[0].read()
-        else:
-            time.sleep(0.1)
+        with lock:
+            fp.reopen()
             fp.write_image(data)
             return fp[0].read()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         fname = os.path.join(
             tmpdir,
-            "fname"
-            + str(uuid.uuid4().hex)
-            + str(thread_index)
-            + str(iteration_index)
-            + ".fits",
+            "fname" + str(uuid.uuid4().hex) + ".fits",
         )
 
         with fitsio.FITS(fname, "rw", clobber=True) as fp:
             fp.write_image(data)
 
         with fitsio.FITS(fname, "rw") as fp:
-            t0 = time.time()
             with ThreadPoolExecutor(max_workers=nt) as exc:
                 futs = [exc.submit(_read_file, fp) for _ in range(nt)]
                 for fut in futs:
                     res = fut.result()
                     np.testing.assert_array_equal(res, data)
-            t0 = time.time() - t0
 
         with fitsio.FITS(fname) as fp:
             n_ext = len(fp)
 
-        print(
-            "thread|iter|n_ext:",
-            thread_index,
-            iteration_index,
-            n_ext,
-            flush=True,
-        )
-
         assert n_ext == nt + 1
-        if sys.version_info.major < 3 or sys.version_info.minor < 13:
-            assert t0 > 1.0
-        else:
-            # locking in the C layer is much more efficient
-            assert t0 > 0.1


### PR DESCRIPTION
It turns out that the lock in the C layer is not sufficient due to stored state in the Python wrappers. We can either add locks in the Python layer (see #524) or we can punt to the user. This PR punts to the user and removes the C layer locks for reentrant builds. Non-reentrant builds still need a global lock in the C layer.